### PR TITLE
replace undeclared identifier binaryName with PROJECT_NAME and remove…

### DIFF
--- a/src/gba/supervisor/config.c
+++ b/src/gba/supervisor/config.c
@@ -130,7 +130,7 @@ void GBAConfigDirectory(char* out, size_t outLength) {
 	char* home = getenv("HOME");
 	snprintf(out, outLength, "%s/.config", home);
 	mkdir(out, 0755);
-	snprintf(out, outLength, "%s/.config/%s", home, binaryName);
+	snprintf(out, outLength, "%s/.config/%s", home, PROJECT_NAME);
 	mkdir(out, 0755);
 #else
 	char home[MAX_PATH];

--- a/src/util/common.h
+++ b/src/util/common.h
@@ -19,8 +19,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "version.h"
-
 #ifdef _MSC_VER
 typedef intptr_t off_t;
 typedef intptr_t ssize_t;


### PR DESCRIPTION
… version.h so further referenced constants from version.c (which we don't generate) will be picked up at build time, rather than failing due to missing symbols at library load time.