### PR TITLE
added HAVE_NEON flag to enable building of src/util/arm-algo.S

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -284,7 +284,7 @@ endif
 
 include $(BUILD_DIR)/Makefile.common
 
-OBJS := $(SOURCES_C:.c=.o)
+OBJS := $(SOURCES_C:.c=.o) $(SOURCES_ASM:.S=.o)
 
 DEFINES += $(PLATFORM_DEFINES) $(RETRODEFS)
 
@@ -294,6 +294,9 @@ LIBS :=
 
 %.o: %.c
 	$(CC) -c -o $@ $< $(CFLAGS) $(INCLUDES)
+%.o: %.S
+	$(CC) -c -o $@ $< $(CFLAGS) $(INCLUDES)
+
 
 ifeq ($(platform), theos_ios)
 COMMON_FLAGS := -DIOS $(COMMON_DEFINES) $(INCLUDES) -I$(THEOS_INCLUDE_PATH) -Wno-error

--- a/libretro-build/Makefile.common
+++ b/libretro-build/Makefile.common
@@ -63,6 +63,10 @@ SOURCES_C :=   $(CORE_DIR)/src/arm/arm.c \
 					$(CORE_DIR)/src/third-party/blip_buf/blip_buf.c \
 					$(CORE_DIR)/src/util/crc32.c
 
+#ifeq ($(HAVE_NEON),1)
+SOURCES_ASM += $(CORE_DIR)/src/util/arm-algo.S
+#endif
+
 ifeq ($(HAVE_VFS_FD),1)
 ifeq ($(platform), vita)
 SOURCES_C += $(CORE_DIR)/src/platform/psp2/sce-vfs.c


### PR DESCRIPTION
This resolves https://github.com/libretro/mgba/issues/17 for me

so when I have CFLAGS="-mcpu=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard"

I can do

make HAVE_NEON=1

