### PR TITLE
added HAVE_NEON flag to enable building of src/util/arm-algo.S - with…

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -286,7 +286,7 @@ endif
 
 include $(BUILD_DIR)/Makefile.common
 
-OBJS := $(SOURCES_C:.c=.o)
+OBJS := $(SOURCES_C:.c=.o) $(SOURCES_ASM:.S=.o)
 
 DEFINES += $(PLATFORM_DEFINES) $(RETRODEFS)
 
@@ -296,6 +296,9 @@ LIBS :=
 
 %.o: %.c
 	$(CC) -c -o $@ $< $(CFLAGS) $(INCLUDES)
+%.o: %.S
+	$(CC) -c -o $@ $< $(CFLAGS) $(INCLUDES)
+
 
 ifeq ($(platform), theos_ios)
 COMMON_FLAGS := -DIOS $(COMMON_DEFINES) $(INCLUDES) -I$(THEOS_INCLUDE_PATH) -Wno-error

--- a/libretro-build/Makefile.common
+++ b/libretro-build/Makefile.common
@@ -63,6 +63,10 @@ SOURCES_C :=   $(CORE_DIR)/src/arm/arm.c \
 					$(CORE_DIR)/src/third-party/blip_buf/blip_buf.c \
 					$(CORE_DIR)/src/util/crc32.c
 
+ifeq ($(HAVE_NEON),1)
+SOURCES_ASM += $(CORE_DIR)/src/util/arm-algo.S
+endif
+
 ifeq ($(HAVE_VFS_FD),1)
 ifeq ($(platform), vita)
 SOURCES_C += $(CORE_DIR)/src/platform/psp2/sce-vfs.c


### PR DESCRIPTION
…out commented out ifeq this time - should fix #17 but not break non NEON builds as #18 did.

@Oggom Please can you check you can still build on mingw with this change