### PR TITLE
small fix on src/gba/core.c

### DIFF
--- a/src/gba/core.c
+++ b/src/gba/core.c
@@ -239,7 +239,7 @@ static void _GBACoreLoadConfig(struct mCore* core, const struct mCoreConfig* con
 
 	mCoreConfigCopyValue(&core->config, config, "gba.bios");
 
-#ifndef DISABLE_THREADING
+#if (!defined(MINIMAL_CORE) || MINIMAL_CORE < 2) && !DISABLE_THREADING
 	mCoreConfigGetIntValue(config, "threadedVideo", &gbacore->threadedVideo);
 #endif
 }


### PR DESCRIPTION
The struct gbacore was declared inside an `#ifdef` declaration (line 221) and later used without the needed def checking.

Noticed that when trying to compile mgba for PS Vita.