### PR TITLE
Makefile.libretro: -DDISABLE_THREADING for Vita

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -194,7 +194,7 @@ else ifeq ($(platform), vita)
    TARGET := $(TARGET_NAME)_libretro_$(platform).a
    CC = arm-vita-eabi-gcc$(EXE_EXT)
    AR = arm-vita-eabi-ar$(EXE_EXT)
-   PLATFORM_DEFINES := -DVITA -DCC_RESAMPLER -DPSP2
+   PLATFORM_DEFINES := -DVITA -DCC_RESAMPLER -DPSP2 -DDISABLE_THREADING
    STATIC_LINKING = 1
    DEFINES += -std=c99
 


### PR DESCRIPTION
This was highlighted by @endrift in [this comment](https://github.com/libretro/mgba/issues/69#issuecomment-325045399).
It partially solves the problems I reported in #69 (most of those "undefined reference" errors).