### PR TITLE
Util: Get rid of _to16Bit

### DIFF
--- a/include/mgba-util/arm-algo.h
+++ b/include/mgba-util/arm-algo.h
@@ -7,8 +7,6 @@
 #define ARM_ALGO_H
 
 #ifdef __arm__
-void _to16Bit(uint16_t* dest, uint32_t* src, size_t words);
-
 #if defined(__ARM_NEON)
 void _neon2x(void* dest, void* src, int width, int height);
 void _neon4x(void* dest, void* src, int width, int height);

--- a/src/gba/renderers/video-software.c
+++ b/src/gba/renderers/video-software.c
@@ -592,13 +592,12 @@ static void GBAVideoSoftwareRendererDrawScanline(struct GBAVideoRenderer* render
 	}
 
 #ifdef COLOR_16_BIT
-#if defined(__ARM_NEON) && !defined(__APPLE__) && !defined(__aarch64__)
-	_to16Bit(row, softwareRenderer->row, VIDEO_HORIZONTAL_PIXELS);
-#else
-	for (x = 0; x < VIDEO_HORIZONTAL_PIXELS; ++x) {
+	for (x = 0; x < VIDEO_HORIZONTAL_PIXELS; x += 4) {
 		row[x] = softwareRenderer->row[x];
+		row[x + 1] = softwareRenderer->row[x + 1];
+		row[x + 2] = softwareRenderer->row[x + 2];
+		row[x + 3] = softwareRenderer->row[x + 3];
 	}
-#endif
 #else
 	memcpy(row, softwareRenderer->row, VIDEO_HORIZONTAL_PIXELS * sizeof(*row));
 #endif

--- a/src/util/arm-algo.S
+++ b/src/util/arm-algo.S
@@ -6,32 +6,6 @@
 #if defined(__ARM_NEON) && !defined(PSP2)
 # r0: Destination
 # r1: Source
-# r2: Number of words to copy as halfwords
-.global _to16Bit
-_to16Bit:
-push {r4-r10}
-mov r8, r0
-mov r9, r1
-mov r10, r2
-.L0:
-tst r10, #15
-beq .L1
-ldr r0, [r9], #4
-strh r0, [r8], #2
-sub r10, #1
-b .L0
-.L1:
-vld4.16 {d0, d1, d2, d3}, [r9]!
-vld4.16 {d4, d5, d6, d7}, [r9]!
-vst2.16 {d0, d2}, [r8]!
-vst2.16 {d4, d6}, [r8]!
-subs r10, #16
-bne .L1
-pop {r4-r10}
-bx lr
-
-# r0: Destination
-# r1: Source
 # r2: Width
 # r3: Height
 .global _neon2x


### PR DESCRIPTION
This is the equivalent to [this commit](https://github.com/mgba-emu/mgba/commit/448bc200c36c68a1250a2eb0394f5b90a2f75bed) from upstream.

It solves the `undefined reference to '_to16Bit'` I reported in #69 .

This solution was pointed out by @endrift in [this comment](https://github.com/libretro/mgba/issues/69#issuecomment-333123549).

One step at a time and soon we will have mgba on PS Vita. :-)