### PR TITLE
Use -std=gnu99 for PS3 instead of -std=c99

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -159,7 +159,7 @@ else ifneq (,$(filter $(platform), ps3 sncps3 psl1ght))
    TARGET := $(TARGET_NAME)_libretro_ps3.a
    PLATFORM_DEFINES := -D__CELLOS_LV2__
    STATIC_LINKING = 1
-   DEFINES += -std=c99 -fms-extensions
+   DEFINES += -std=gnu99 -fms-extensions
    HAVE_VFS_FD = 0
 
    # sncps3


### PR DESCRIPTION
This is a fix from endrift to avoid many build failures.