### PR TITLE
Fix undefined symbols when loading the library

### DIFF
--- a/.travis-deps.sh
+++ b/.travis-deps.sh
@@ -2,11 +2,6 @@
 if [ $TRAVIS_OS_NAME = "osx" ]; then
 	brew update
 	brew install qt5 ffmpeg imagemagick sdl2 libzip libpng
-	if [ "$CC" == "gcc" ]; then
-		brew install gcc@4.9
-		export CC=gcc-4.9
-		export CXX=g++-4.9
-	fi
 else
 	sudo apt-get clean
 	sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ matrix:
       compiler: gcc
     - os: osx
       compiler: clang
-    - os: osx
-      compiler: gcc
 
 before_install:
   - source ./.travis-deps.sh

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -282,7 +282,9 @@ DEFINES += $(PLATFORM_DEFINES) $(RETRODEFS)
 
 CFLAGS += $(CODE_DEFINES) $(fpic) $(DEFINES)
 
-LIBS :=
+ifeq (,$(findstring msvc,$(platform)))
+LIBS += -lm
+endif
 
 %.o: %.c
 	$(CC) -c -o $@ $< $(CFLAGS) $(INCLUDES)

--- a/src/gb/core.c
+++ b/src/gb/core.c
@@ -746,6 +746,7 @@ static void _GBCoreEnableAudioChannel(struct mCore* core, size_t id, bool enable
 	}
 }
 
+#ifndef MINIMAL_CORE
 static void _GBCoreStartVideoLog(struct mCore* core, struct mVideoLogContext* context) {
 	struct GBCore* gbcore = (struct GBCore*) core;
 	struct GB* gb = core->board;
@@ -768,6 +769,7 @@ static void _GBCoreEndVideoLog(struct mCore* core) {
 	free(gbcore->proxyRenderer.logger);
 	gbcore->proxyRenderer.logger = NULL;
 }
+#endif
 
 struct mCore* GBCoreCreate(void) {
 	struct GBCore* gbcore = malloc(sizeof(*gbcore));

--- a/src/gba/cheats/parv3.c
+++ b/src/gba/cheats/parv3.c
@@ -223,7 +223,7 @@ bool GBACheatAddProActionReplayRaw(struct GBACheatSet* cheats, uint32_t op1, uin
 		struct mCheat* incompleteCheat = mCheatListGetPointer(&cheats->d.list, cheats->incompleteCheat);
 		incompleteCheat->operand = op1 & (0xFFFFFFFFU >> ((4 - incompleteCheat->width) * 8));
 		incompleteCheat->operandOffset = op2 >> 24;
-		incompleteCheat->repeat = ((op2 >> 16) & 0xFF) + 1;
+		incompleteCheat->repeat = (op2 >> 16) & 0xFF;
 		incompleteCheat->addressOffset = (op2 & 0xFFFF) * incompleteCheat->width;
 		cheats->incompleteCheat = COMPLETE;
 		return true;

--- a/src/gba/core.c
+++ b/src/gba/core.c
@@ -805,6 +805,7 @@ static void _GBACoreEnableAudioChannel(struct mCore* core, size_t id, bool enabl
 	}
 }
 
+#ifndef MINIMAL_CORE
 static void _GBACoreStartVideoLog(struct mCore* core, struct mVideoLogContext* context) {
 	struct GBACore* gbacore = (struct GBACore*) core;
 	struct GBA* gba = core->board;
@@ -831,6 +832,7 @@ static void _GBACoreEndVideoLog(struct mCore* core) {
 	free(gbacore->proxyRenderer.logger);
 	gbacore->proxyRenderer.logger = NULL;
 }
+#endif
 
 struct mCore* GBACoreCreate(void) {
 	struct GBACore* gbacore = malloc(sizeof(*gbacore));

--- a/src/gba/test/cheats.c
+++ b/src/gba/test/cheats.c
@@ -1016,6 +1016,7 @@ M_TEST_DEFINE(doPARv3IfXContain1ElseContain1) {
 	assert_int_equal(core->rawRead8(core, 0x03000006, -1), 0x62);
 	assert_int_equal(core->rawRead8(core, 0x03000007, -1), 0x71);
 	assert_int_equal(core->rawRead8(core, 0x03000008, -1), 0x82);
+	set->deinit(set);
 }
 
 M_TEST_SUITE_DEFINE_SETUP_TEARDOWN(GBACheats,


### PR DESCRIPTION
$ make && ldd -r mgba_libretro.so
undefined symbol: powf  (./mgba_libretro.so)
undefined symbol: sqrt  (./mgba_libretro.so)
undefined symbol: sincosf       (./mgba_libretro.so)

$ make DEBUG=1 && ldd -r mgba_libretro.so
undefined symbol: GBAVideoProxyRendererCreate   (./mgba_libretro.so)
undefined symbol: sinf  (./mgba_libretro.so)
undefined symbol: mVideoLoggerRendererCreate    (./mgba_libretro.so)
undefined symbol: powf  (./mgba_libretro.so)
undefined symbol: cosf  (./mgba_libretro.so)
undefined symbol: GBVideoProxyRendererShim      (./mgba_libretro.so)
undefined symbol: GBAVideoProxyRendererUnshim   (./mgba_libretro.so)
undefined symbol: mVideoLogContextInitialState  (./mgba_libretro.so)
undefined symbol: GBVideoProxyRendererCreate    (./mgba_libretro.so)
undefined symbol: mVideoLoggerAddChannel        (./mgba_libretro.so)
undefined symbol: GBAVideoProxyRendererShim     (./mgba_libretro.so)
undefined symbol: mVideoLoggerAttachChannel     (./mgba_libretro.so)
undefined symbol: sqrt  (./mgba_libretro.so)
undefined symbol: GBVideoProxyRendererUnshim    (./mgba_libretro.so)