### PR TITLE
add frameskip core option from upstream commit 6f5ec7d

### DIFF
--- a/src/platform/libretro/libretro.c
+++ b/src/platform/libretro/libretro.c
@@ -96,6 +96,13 @@ static void _reloadSettings(void) {
 			mCoreConfigSetDefaultValue(&core->config, "idleOptimization", "detect");
 		}
 	}
+	
+	var.key = "mgba_frameskip";
+	var.value = 0;
+	if (environCallback(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) {
+		opts.frameskip = strtol(var.value, NULL, 10);
+
+	}
 
 	mCoreConfigLoadDefaults(&core->config, &opts);
 	mCoreLoadConfig(core);
@@ -114,6 +121,7 @@ void retro_set_environment(retro_environment_t env) {
 		{ "mgba_use_bios", "Use BIOS file if found; ON|OFF" },
 		{ "mgba_skip_bios", "Skip BIOS intro; OFF|ON" },
 		{ "mgba_idle_optimization", "Idle loop removal; Remove Known|Detect and Remove|Don't Remove" },
+		{ "mgba_frameskip", "Frameskip; 0|1|2|3|4|5|6|7|8|9|10" },
 		{ 0, 0 }
 	};
 
@@ -284,6 +292,13 @@ void retro_run(void) {
 		if (environCallback(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) {
 			((struct GBA*) core->board)->allowOpposingDirections = strcmp(var.value, "yes") == 0;
 		}
+		
+		var.key = "mgba_frameskip";
+		var.value = 0;
+		if (environCallback(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) {
+			mCoreConfigSetUIntValue(&core->config, "frameskip", strtol(var.value, NULL, 10));
+			mCoreLoadConfig(core);
+	 	}
 	}
 
 	keys = 0;

--- a/src/platform/libretro/libretro.c
+++ b/src/platform/libretro/libretro.c
@@ -101,7 +101,6 @@ static void _reloadSettings(void) {
 	var.value = 0;
 	if (environCallback(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) {
 		opts.frameskip = strtol(var.value, NULL, 10);
-
 	}
 
 	mCoreConfigLoadDefaults(&core->config, &opts);


### PR DESCRIPTION
copied by hand from https://github.com/mgba-emu/mgba/commit/cee6569bde476ea94e05237baf62d3d4ce1d2cf9, since git didn't want to cooperate with rebase/merge/cherry-picking.