### PR TITLE
Add savetype overrides for e-Reader

### DIFF
--- a/src/gba/overrides.c
+++ b/src/gba/overrides.c
@@ -49,6 +49,10 @@ static const struct GBACartridgeOverride _overrides[] = {
 	// Drill Dozer
 	{ "V49J", SAVEDATA_SRAM, HW_RUMBLE, IDLE_LOOP_NONE, false },
 	{ "V49E", SAVEDATA_SRAM, HW_RUMBLE, IDLE_LOOP_NONE, false },
+    
+    // e-Reader
+	{ "PSAJ", SAVEDATA_FLASH1M, HW_NONE, IDLE_LOOP_NONE, false },
+	{ "PSAE", SAVEDATA_FLASH1M, HW_NONE, IDLE_LOOP_NONE, false },
 
 	// Final Fantasy Tactics Advance
 	{ "AFXE", SAVEDATA_FLASH512, HW_NONE, 0x8000428, false },


### PR DESCRIPTION
Booting the game throws a save error otherwise. This allows saves made in VBA to function the same in mGBA.

Before:
![e-reader usa -180213-103903](https://user-images.githubusercontent.com/33245078/36162108-272f8ea2-10ab-11e8-917e-9e01e9239684.png)

After:
![e-reader usa -180213-104140](https://user-images.githubusercontent.com/33245078/36162100-20efeffa-10ab-11e8-98a1-43d3f9168bd5.png)
