### PR TITLE
Libretro: Fix root issue for config crash

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -264,9 +264,9 @@ else ifeq ($(platform), libnx)
 	STATIC_LINKING_LINK=1
 	HAVE_VFS_FD = 0
 	CFLAGS += -O3 -fomit-frame-pointer -ffast-math -I$(LIBNX)/include/ -fPIE -Wl,--allow-multiple-definition -specs=$(LIBNX)/switch.specs
-	DEFINES += -std=c99
+	DEFINES += -std=gnu11
 	ASFLAGS += -DHAVE_LIBNX
-	PLATFORM_DEFINES += -D__SWITCH__ -DHAVE_LIBNX
+	PLATFORM_DEFINES += -D__SWITCH__ -DHAVE_LIBNX -DHAVE_LOCALE
 	PLATFORM_DEFINES += -march=armv8-a -mtune=cortex-a57 -mtp=soft -fPIE -mcpu=cortex-a57+crc+fp+simd -DHAVE_INTTYPES -DLSB_FIRST -DINLINE=inline
 
 # Nintendo Switch (libtransistor)

--- a/src/core/config.c
+++ b/src/core/config.c
@@ -325,10 +325,6 @@ void mCoreConfigCopyValue(struct mCoreConfig* config, const struct mCoreConfig* 
 }
 
 void mCoreConfigMap(const struct mCoreConfig* config, struct mCoreOptions* opts) {
-#ifdef HAVE_LIBNX // Needed or fatal
-    return;
-#endif
-
 	_lookupCharValue(config, "bios", &opts->bios);
 	_lookupCharValue(config, "shader", &opts->shader);
 	_lookupIntValue(config, "logLevel", &opts->logLevel);

--- a/src/core/core.c
+++ b/src/core/core.c
@@ -294,9 +294,7 @@ void mCoreLoadForeignConfig(struct mCore* core, const struct mCoreConfig* config
 	mCoreConfigCopyValue(&core->config, config, "cheatAutosave");
 	mCoreConfigCopyValue(&core->config, config, "cheatAutoload");
 
-#ifndef HAVE_LIBNX // Needed or fatal
 	core->loadConfig(core, config);
-#endif
 }
 
 void mCoreSetRTC(struct mCore* core, struct mRTCSource* rtc) {


### PR DESCRIPTION
Now config options will work again without crashing.

Problem was that strdup wasn't exposed in the header so the return value was getting truncated (because C default return type is int, which is the wrong size on Switch).