### PR TITLE
Small hack to allow loading 32mb roms on Wii Retroarch port.

### DIFF
--- a/src/platform/libretro/libretro.c
+++ b/src/platform/libretro/libretro.c
@@ -203,7 +203,11 @@ void retro_set_input_state(retro_input_state_t input) {
 }
 
 void retro_get_system_info(struct retro_system_info* info) {
-	info->need_fullpath = false;
+#ifdef GEKKO
+   info->need_fullpath = true;
+#else
+   info->need_fullpath = false;
+#endif
 	info->valid_extensions = "gba|gb|gbc";
 #ifndef GIT_VERSION
 #define GIT_VERSION ""
@@ -528,6 +532,38 @@ void retro_reset(void) {
 	rumbleDown = 0;
 }
 
+#ifdef GEKKO
+static size_t _readRomFile(const char *path, void **buf)
+{
+	size_t rc;
+	long len;
+	FILE *file = fopen(path, "rb");
+
+	if (!file)
+		goto error;
+
+	fseek(file, 0, SEEK_END);
+	len = ftell(file);
+	rewind(file);
+	*buf = anonymousMemoryMap(len);
+	if (!*buf)
+		goto error;
+
+	if ((rc = fread(*buf, 1, len, file)) < len)
+		goto error;
+
+	fclose(file);
+	return rc;
+
+error:
+	if (file)
+		fclose(file);
+	mappedMemoryFree(*buf, len);
+	*buf = NULL;
+	return -1;
+}
+#endif
+
 bool retro_load_game(const struct retro_game_info* game)
 {
 	struct VFile* rom;
@@ -541,8 +577,14 @@ bool retro_load_game(const struct retro_game_info* game)
 		memcpy(data, game->data, game->size);
 		rom = VFileFromMemory(data, game->size);
 	} else {
+#ifdef GEKKO
+		if ((dataSize = _readRomFile(game->path, &data)) == -1)
+			return false;
+		rom = VFileFromMemory(data, dataSize);
+#else
 		data = 0;
 		rom = VFileOpen(game->path, O_RDONLY);
+#endif
 	}
 	if (!rom) {
 		return false;

--- a/src/platform/libretro/libretro.c
+++ b/src/platform/libretro/libretro.c
@@ -533,43 +533,46 @@ void retro_reset(void) {
 }
 
 #ifdef GEKKO
-static size_t _readRomFile(const char *path, void **buf)
-{
+static size_t _readRomFile(const char *path, void **buf) {
 	size_t rc;
 	long len;
 	FILE *file = fopen(path, "rb");
 
-	if (!file)
+	if (!file) {
 		goto error;
+	}
 
 	fseek(file, 0, SEEK_END);
 	len = ftell(file);
 	rewind(file);
 	*buf = anonymousMemoryMap(len);
-	if (!*buf)
+	if (!*buf) {
 		goto error;
+	}
 
-	if ((rc = fread(*buf, 1, len, file)) < len)
+	if ((rc = fread(*buf, 1, len, file)) < len) {
 		goto error;
+	}
 
 	fclose(file);
 	return rc;
 
 error:
-	if (file)
+	if (file) {
 		fclose(file);
+	}
 	mappedMemoryFree(*buf, len);
 	*buf = NULL;
 	return -1;
 }
 #endif
 
-bool retro_load_game(const struct retro_game_info* game)
-{
+bool retro_load_game(const struct retro_game_info* game) {
 	struct VFile* rom;
 
-   if (!game)
-      return false;
+	if (!game) {
+		return false;
+	}
 
 	if (game->data) {
 		data = anonymousMemoryMap(game->size);
@@ -578,8 +581,9 @@ bool retro_load_game(const struct retro_game_info* game)
 		rom = VFileFromMemory(data, game->size);
 	} else {
 #ifdef GEKKO
-		if ((dataSize = _readRomFile(game->path, &data)) == -1)
+		if ((dataSize = _readRomFile(game->path, &data)) == -1) {
 			return false;
+		}
 		rom = VFileFromMemory(data, dataSize);
 #else
 		data = 0;


### PR DESCRIPTION
Don't know if people is still interested on this but I'm submitting a fix for issue https://github.com/libretro/libretro-meta/issues/24

Basically the problem was that Retroarch loads the ROM file into memory and passes it to the core which then allocates enough memory again to copy it and use it. But for 32MB ROMS there is not enough memory left for this.

The fix is simply use the other approach in Libretro to allow the core load the ROM and just pass to it the full path.

I also fixed this for VBA-Next which has the same problem and it was solved in the same way.