### PR TITLE
Updated cross-makefiles

### DIFF
--- a/libretro-build/Makefile.android_arm64-v8a
+++ b/libretro-build/Makefile.android_arm64-v8a
@@ -24,10 +24,10 @@ TARGET_PLATFORM = android_arm64-v8a
 #################
 # Toolchain setup
 
-CC  = $(NDK_ROOT_DIR)/toolchains/aarch64-linux-android-4.9/prebuilt/$(HOST_PLATFORM)-x86_64/bin/aarch64-linux-android-gcc
-CXX = $(NDK_ROOT_DIR)/toolchains/aarch64-linux-android-4.9/prebuilt/$(HOST_PLATFORM)-x86_64/bin/aarch64-linux-android-g++
-AS  = $(NDK_ROOT_DIR)/toolchains/aarch64-linux-android-4.9/prebuilt/$(HOST_PLATFORM)-x86_64/bin/aarch64-linux-android-as
-AR  = $(NDK_ROOT_DIR)/toolchains/aarch64-linux-android-4.9/prebuilt/$(HOST_PLATFORM)-x86_64/bin/aarch64-linux-android-ar
+CC  = $(NDK_ROOT_DIR)/toolchains/aarch64-linux-android-$(NDK_TOOLCHAIN_VERSION)/prebuilt/$(HOST_PLATFORM)-x86_64/bin/aarch64-linux-android-gcc
+CXX = $(NDK_ROOT_DIR)/toolchains/aarch64-linux-android-$(NDK_TOOLCHAIN_VERSION)/prebuilt/$(HOST_PLATFORM)-x86_64/bin/aarch64-linux-android-g++
+AS  = $(NDK_ROOT_DIR)/toolchains/aarch64-linux-android-$(NDK_TOOLCHAIN_VERSION)/prebuilt/$(HOST_PLATFORM)-x86_64/bin/aarch64-linux-android-as
+AR  = $(NDK_ROOT_DIR)/toolchains/aarch64-linux-android-$(NDK_TOOLCHAIN_VERSION)/prebuilt/$(HOST_PLATFORM)-x86_64/bin/aarch64-linux-android-ar
 
 ############
 # Extensions
@@ -41,11 +41,11 @@ LIBEXT = .android_arm64-v8a.a
 
 STATIC_LINKING = 0
 platform       = android
-PLATDEFS       = -DANDROID -DINLINE=inline -DHAVE_STDINT_H -DBSPF_UNIX -DHAVE_INTTYPES -DLSB_FIRST -DHAVE_LOCALE
+PLATDEFS       = -DANDROID -DINLINE=inline -DHAVE_STDINT_H -DBSPF_UNIX -DHAVE_INTTYPES -DLSB_FIRST
 PLATCFLAGS     = -fpic -ffunction-sections -funwind-tables -fstack-protector -no-canonical-prefixes -fomit-frame-pointer -fstrict-aliasing -funswitch-loops -finline-limit=300 -Wa,--noexecstack -Wformat -Werror=format-security
 PLATCXXFLAGS   = -fpic -ffunction-sections -funwind-tables -fstack-protector -no-canonical-prefixes -fomit-frame-pointer -fstrict-aliasing -funswitch-loops -finline-limit=300 -Wa,--noexecstack -Wformat -Werror=format-security -fno-exceptions -fno-rtti
 PLATLDFLAGS    = -shared --sysroot=$(NDK_ROOT_DIR)/platforms/android-21/arch-arm64 -lgcc -no-canonical-prefixes -Wl,--no-undefined -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -lc -lm
-PLATLDXFLAGS   = -shared --sysroot=$(NDK_ROOT_DIR)/platforms/android-21/arch-arm64 -lgcc -no-canonical-prefixes -Wl,--no-undefined -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -lc -lm $(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/4.9/libs/arm64-v8a/libgnustl_static.a
+PLATLDXFLAGS   = -shared --sysroot=$(NDK_ROOT_DIR)/platforms/android-21/arch-arm64 -lgcc -no-canonical-prefixes -Wl,--no-undefined -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -lc -lm $(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/libs/arm64-v8a/libgnustl_static.a
 
 ################
 # libretro setup
@@ -86,7 +86,7 @@ endif
 
 CORE_DIR  ?= ..
 BUILD_DIR ?= .
-INCLUDES   = -I$(NDK_ROOT_DIR)/platforms/android-21/arch-arm64/usr/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/4.9/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/4.9/libs/arm64-v8a/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/4.9/include/backward
+INCLUDES   = -I$(NDK_ROOT_DIR)/platforms/android-21/arch-arm64/usr/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/libs/arm64-v8a/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/include/backward
 
 include $(BUILD_DIR)/Makefile.common
 

--- a/libretro-build/Makefile.android_armeabi
+++ b/libretro-build/Makefile.android_armeabi
@@ -24,10 +24,10 @@ TARGET_PLATFORM = android_armeabi
 #################
 # Toolchain setup
 
-CC  = $(NDK_ROOT_DIR)/toolchains/arm-linux-androideabi-4.9/prebuilt/$(HOST_PLATFORM)-x86_64/bin/arm-linux-androideabi-gcc
-CXX = $(NDK_ROOT_DIR)/toolchains/arm-linux-androideabi-4.9/prebuilt/$(HOST_PLATFORM)-x86_64/bin/arm-linux-androideabi-g++
-AS  = $(NDK_ROOT_DIR)/toolchains/arm-linux-androideabi-4.9/prebuilt/$(HOST_PLATFORM)-x86_64/bin/arm-linux-androideabi-as
-AR  = $(NDK_ROOT_DIR)/toolchains/arm-linux-androideabi-4.9/prebuilt/$(HOST_PLATFORM)-x86_64/bin/arm-linux-androideabi-ar
+CC  = $(NDK_ROOT_DIR)/toolchains/arm-linux-androideabi-$(NDK_TOOLCHAIN_VERSION)/prebuilt/$(HOST_PLATFORM)-x86_64/bin/arm-linux-androideabi-gcc
+CXX = $(NDK_ROOT_DIR)/toolchains/arm-linux-androideabi-$(NDK_TOOLCHAIN_VERSION)/prebuilt/$(HOST_PLATFORM)-x86_64/bin/arm-linux-androideabi-g++
+AS  = $(NDK_ROOT_DIR)/toolchains/arm-linux-androideabi-$(NDK_TOOLCHAIN_VERSION)/prebuilt/$(HOST_PLATFORM)-x86_64/bin/arm-linux-androideabi-as
+AR  = $(NDK_ROOT_DIR)/toolchains/arm-linux-androideabi-$(NDK_TOOLCHAIN_VERSION)/prebuilt/$(HOST_PLATFORM)-x86_64/bin/arm-linux-androideabi-ar
 
 ############
 # Extensions
@@ -45,7 +45,7 @@ PLATDEFS       = -DANDROID -DINLINE=inline -DHAVE_STDINT_H -DBSPF_UNIX -DHAVE_IN
 PLATCFLAGS     = -fpic -ffunction-sections -funwind-tables -fstack-protector -no-canonical-prefixes -march=armv5te -mtune=xscale -msoft-float -fomit-frame-pointer -fstrict-aliasing -funswitch-loops -finline-limit=300 -Wa,--noexecstack -Wformat -Werror=format-security
 PLATCXXFLAGS   = -fpic -ffunction-sections -funwind-tables -fstack-protector -no-canonical-prefixes -march=armv5te -mtune=xscale -msoft-float -fomit-frame-pointer -fstrict-aliasing -funswitch-loops -finline-limit=300 -Wa,--noexecstack -Wformat -Werror=format-security -fno-exceptions -fno-rtti
 PLATLDFLAGS    = -shared --sysroot=$(NDK_ROOT_DIR)/platforms/android-9/arch-arm -lgcc -no-canonical-prefixes -Wl,--no-undefined -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -lc -lm
-PLATLDXFLAGS   = -shared --sysroot=$(NDK_ROOT_DIR)/platforms/android-9/arch-arm -lgcc -no-canonical-prefixes -Wl,--no-undefined -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -lc -lm $(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/4.9/libs/armeabi/libgnustl_static.a
+PLATLDXFLAGS   = -shared --sysroot=$(NDK_ROOT_DIR)/platforms/android-9/arch-arm -lgcc -no-canonical-prefixes -Wl,--no-undefined -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -lc -lm $(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/libs/armeabi/libgnustl_static.a
 
 ################
 # libretro setup
@@ -86,7 +86,7 @@ endif
 
 CORE_DIR  ?= ..
 BUILD_DIR ?= .
-INCLUDES   = -I$(NDK_ROOT_DIR)/platforms/android-9/arch-arm/usr/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/4.9/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/4.9/libs/armeabi/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/4.9/include/backward
+INCLUDES   = -I$(NDK_ROOT_DIR)/platforms/android-9/arch-arm/usr/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/libs/armeabi/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/include/backward
 
 include $(BUILD_DIR)/Makefile.common
 

--- a/libretro-build/Makefile.android_armeabi-v7a
+++ b/libretro-build/Makefile.android_armeabi-v7a
@@ -24,10 +24,10 @@ TARGET_PLATFORM = android_armeabi-v7a
 #################
 # Toolchain setup
 
-CC  = $(NDK_ROOT_DIR)/toolchains/arm-linux-androideabi-4.9/prebuilt/$(HOST_PLATFORM)-x86_64/bin/arm-linux-androideabi-gcc
-CXX = $(NDK_ROOT_DIR)/toolchains/arm-linux-androideabi-4.9/prebuilt/$(HOST_PLATFORM)-x86_64/bin/arm-linux-androideabi-g++
-AS  = $(NDK_ROOT_DIR)/toolchains/arm-linux-androideabi-4.9/prebuilt/$(HOST_PLATFORM)-x86_64/bin/arm-linux-androideabi-as
-AR  = $(NDK_ROOT_DIR)/toolchains/arm-linux-androideabi-4.9/prebuilt/$(HOST_PLATFORM)-x86_64/bin/arm-linux-androideabi-ar
+CC  = $(NDK_ROOT_DIR)/toolchains/arm-linux-androideabi-$(NDK_TOOLCHAIN_VERSION)/prebuilt/$(HOST_PLATFORM)-x86_64/bin/arm-linux-androideabi-gcc
+CXX = $(NDK_ROOT_DIR)/toolchains/arm-linux-androideabi-$(NDK_TOOLCHAIN_VERSION)/prebuilt/$(HOST_PLATFORM)-x86_64/bin/arm-linux-androideabi-g++
+AS  = $(NDK_ROOT_DIR)/toolchains/arm-linux-androideabi-$(NDK_TOOLCHAIN_VERSION)/prebuilt/$(HOST_PLATFORM)-x86_64/bin/arm-linux-androideabi-as
+AR  = $(NDK_ROOT_DIR)/toolchains/arm-linux-androideabi-$(NDK_TOOLCHAIN_VERSION)/prebuilt/$(HOST_PLATFORM)-x86_64/bin/arm-linux-androideabi-ar
 
 ############
 # Extensions
@@ -41,11 +41,11 @@ LIBEXT = .android_armeabi-v7a.a
 
 STATIC_LINKING = 0
 platform       = android
-PLATDEFS       = -DANDROID -DINLINE=inline -DHAVE_STDINT_H -DBSPF_UNIX -DHAVE_INTTYPES -DLSB_FIRST -DHAVE_LOCALE
+PLATDEFS       = -DANDROID -DINLINE=inline -DHAVE_STDINT_H -DBSPF_UNIX -DHAVE_INTTYPES -DLSB_FIRST
 PLATCFLAGS     = -fpic -ffunction-sections -funwind-tables -fstack-protector -no-canonical-prefixes -march=armv7-a -mfpu=vfpv3-d16 -mfloat-abi=softfp -fomit-frame-pointer -fstrict-aliasing -funswitch-loops -finline-limit=300 -Wa,--noexecstack -Wformat -Werror=format-security
 PLATCXXFLAGS   = -fpic -ffunction-sections -funwind-tables -fstack-protector -no-canonical-prefixes -march=armv7-a -mfpu=vfpv3-d16 -mfloat-abi=softfp -fomit-frame-pointer -fstrict-aliasing -funswitch-loops -finline-limit=300 -Wa,--noexecstack -Wformat -Werror=format-security -fno-exceptions -fno-rtti
-PLATLDFLAGS    = -shared --sysroot=$(NDK_ROOT_DIR)/platforms/android-21/arch-arm -lgcc -no-canonical-prefixes -march=armv7-a -Wl,--fix-cortex-a8 -Wl,--no-undefined -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -lc -lm
-PLATLDXFLAGS   = -shared --sysroot=$(NDK_ROOT_DIR)/platforms/android-21/arch-arm -lgcc -no-canonical-prefixes -march=armv7-a -Wl,--fix-cortex-a8 -Wl,--no-undefined -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -lc -lm $(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/4.9/libs/armeabi-v7a/libgnustl_static.a
+PLATLDFLAGS    = -shared --sysroot=$(NDK_ROOT_DIR)/platforms/android-19/arch-arm -lgcc -no-canonical-prefixes -march=armv7-a -Wl,--fix-cortex-a8 -Wl,--no-undefined -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -lc -lm
+PLATLDXFLAGS   = -shared --sysroot=$(NDK_ROOT_DIR)/platforms/android-19/arch-arm -lgcc -no-canonical-prefixes -march=armv7-a -Wl,--fix-cortex-a8 -Wl,--no-undefined -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -lc -lm $(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/libs/armeabi-v7a/libgnustl_static.a
 
 ################
 # libretro setup
@@ -86,7 +86,7 @@ endif
 
 CORE_DIR  ?= ..
 BUILD_DIR ?= .
-INCLUDES   = -I$(NDK_ROOT_DIR)/platforms/android-21/arch-arm/usr/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/4.9/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/4.9/libs/armeabi/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/4.9/include/backward
+INCLUDES   = -I$(NDK_ROOT_DIR)/platforms/android-19/arch-arm/usr/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/libs/armeabi/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/include/backward
 
 include $(BUILD_DIR)/Makefile.common
 

--- a/libretro-build/Makefile.android_mips
+++ b/libretro-build/Makefile.android_mips
@@ -24,10 +24,10 @@ TARGET_PLATFORM = android_mips
 #################
 # Toolchain setup
 
-CC  = $(NDK_ROOT_DIR)/toolchains/mipsel-linux-android-4.9/prebuilt/$(HOST_PLATFORM)-x86_64/bin/mipsel-linux-android-gcc
-CXX = $(NDK_ROOT_DIR)/toolchains/mipsel-linux-android-4.9/prebuilt/$(HOST_PLATFORM)-x86_64/bin/mipsel-linux-android-g++
-AS  = $(NDK_ROOT_DIR)/toolchains/mipsel-linux-android-4.9/prebuilt/$(HOST_PLATFORM)-x86_64/bin/mipsel-linux-android-as
-AR  = $(NDK_ROOT_DIR)/toolchains/mipsel-linux-android-4.9/prebuilt/$(HOST_PLATFORM)-x86_64/bin/mipsel-linux-android-ar
+CC  = $(NDK_ROOT_DIR)/toolchains/mipsel-linux-android-$(NDK_TOOLCHAIN_VERSION)/prebuilt/$(HOST_PLATFORM)-x86_64/bin/mipsel-linux-android-gcc
+CXX = $(NDK_ROOT_DIR)/toolchains/mipsel-linux-android-$(NDK_TOOLCHAIN_VERSION)/prebuilt/$(HOST_PLATFORM)-x86_64/bin/mipsel-linux-android-g++
+AS  = $(NDK_ROOT_DIR)/toolchains/mipsel-linux-android-$(NDK_TOOLCHAIN_VERSION)/prebuilt/$(HOST_PLATFORM)-x86_64/bin/mipsel-linux-android-as
+AR  = $(NDK_ROOT_DIR)/toolchains/mipsel-linux-android-$(NDK_TOOLCHAIN_VERSION)/prebuilt/$(HOST_PLATFORM)-x86_64/bin/mipsel-linux-android-ar
 
 ############
 # Extensions
@@ -45,7 +45,7 @@ PLATDEFS       = -DANDROID -DINLINE=inline -DHAVE_STDINT_H -DBSPF_UNIX -DHAVE_IN
 PLATCFLAGS     = -fpic -fno-strict-aliasing -finline-functions -ffunction-sections -funwind-tables -fmessage-length=0 -fno-inline-functions-called-once -fgcse-after-reload -frerun-cse-after-loop -frename-registers -no-canonical-prefixes -fomit-frame-pointer -funswitch-loops -finline-limit=300 -Wa,--noexecstack -Wformat -Werror=format-security
 PLATCXXFLAGS   = -fpic -fno-strict-aliasing -finline-functions -ffunction-sections -funwind-tables -fmessage-length=0 -fno-inline-functions-called-once -fgcse-after-reload -frerun-cse-after-loop -frename-registers -no-canonical-prefixes -fomit-frame-pointer -funswitch-loops -finline-limit=300 -Wa,--noexecstack -Wformat -Werror=format-security -fno-exceptions -fno-rtti
 PLATLDFLAGS    = -shared --sysroot=$(NDK_ROOT_DIR)/platforms/android-9/arch-mips -lgcc -no-canonical-prefixes -Wl,--no-undefined -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -lc -lm
-PLATLDXFLAGS   = -shared --sysroot=$(NDK_ROOT_DIR)/platforms/android-9/arch-mips -lgcc -no-canonical-prefixes -Wl,--no-undefined -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -lc -lm $(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/4.9/libs/mips/libgnustl_static.a
+PLATLDXFLAGS   = -shared --sysroot=$(NDK_ROOT_DIR)/platforms/android-9/arch-mips -lgcc -no-canonical-prefixes -Wl,--no-undefined -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -lc -lm $(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/libs/mips/libgnustl_static.a
 
 ################
 # libretro setup
@@ -86,7 +86,7 @@ endif
 
 CORE_DIR  ?= ..
 BUILD_DIR ?= .
-INCLUDES   = -I$(NDK_ROOT_DIR)/platforms/android-9/arch-mips/usr/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/4.9/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/4.9/libs/mips/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/4.9/include/backward
+INCLUDES   = -I$(NDK_ROOT_DIR)/platforms/android-9/arch-mips/usr/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/libs/mips/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/include/backward
 
 include $(BUILD_DIR)/Makefile.common
 

--- a/libretro-build/Makefile.android_mips64
+++ b/libretro-build/Makefile.android_mips64
@@ -24,10 +24,10 @@ TARGET_PLATFORM = android_mips64
 #################
 # Toolchain setup
 
-CC  = $(NDK_ROOT_DIR)/toolchains/mips64el-linux-android-4.9/prebuilt/$(HOST_PLATFORM)-x86_64/bin/mips64el-linux-android-gcc
-CXX = $(NDK_ROOT_DIR)/toolchains/mips64el-linux-android-4.9/prebuilt/$(HOST_PLATFORM)-x86_64/bin/mips64el-linux-android-g++
-AS  = $(NDK_ROOT_DIR)/toolchains/mips64el-linux-android-4.9/prebuilt/$(HOST_PLATFORM)-x86_64/bin/mips64el-linux-android-as
-AR  = $(NDK_ROOT_DIR)/toolchains/mips64el-linux-android-4.9/prebuilt/$(HOST_PLATFORM)-x86_64/bin/mips64el-linux-android-ar
+CC  = $(NDK_ROOT_DIR)/toolchains/mips64el-linux-android-$(NDK_TOOLCHAIN_VERSION)/prebuilt/$(HOST_PLATFORM)-x86_64/bin/mips64el-linux-android-gcc
+CXX = $(NDK_ROOT_DIR)/toolchains/mips64el-linux-android-$(NDK_TOOLCHAIN_VERSION)/prebuilt/$(HOST_PLATFORM)-x86_64/bin/mips64el-linux-android-g++
+AS  = $(NDK_ROOT_DIR)/toolchains/mips64el-linux-android-$(NDK_TOOLCHAIN_VERSION)/prebuilt/$(HOST_PLATFORM)-x86_64/bin/mips64el-linux-android-as
+AR  = $(NDK_ROOT_DIR)/toolchains/mips64el-linux-android-$(NDK_TOOLCHAIN_VERSION)/prebuilt/$(HOST_PLATFORM)-x86_64/bin/mips64el-linux-android-ar
 
 ############
 # Extensions
@@ -45,7 +45,7 @@ PLATDEFS       = -DANDROID -DINLINE=inline -DHAVE_STDINT_H -DBSPF_UNIX -DHAVE_IN
 PLATCFLAGS     = -fpic -fno-strict-aliasing -finline-functions -ffunction-sections -funwind-tables -fmessage-length=0 -fno-inline-functions-called-once -fgcse-after-reload -frerun-cse-after-loop -frename-registers -no-canonical-prefixes -fomit-frame-pointer -funswitch-loops -finline-limit=300 -Wa,--noexecstack -Wformat -Werror=format-security
 PLATCXXFLAGS   = -fpic -fno-strict-aliasing -finline-functions -ffunction-sections -funwind-tables -fmessage-length=0 -fno-inline-functions-called-once -fgcse-after-reload -frerun-cse-after-loop -frename-registers -no-canonical-prefixes -fomit-frame-pointer -funswitch-loops -finline-limit=300 -Wa,--noexecstack -Wformat -Werror=format-security -fno-exceptions -fno-rtti
 PLATLDFLAGS    = -shared --sysroot=$(NDK_ROOT_DIR)/platforms/android-21/arch-mips64 -lgcc -no-canonical-prefixes -Wl,--no-undefined -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -lc -lm
-PLATLDXFLAGS   = -shared --sysroot=$(NDK_ROOT_DIR)/platforms/android-21/arch-mips64 -lgcc -no-canonical-prefixes -Wl,--no-undefined -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -lc -lm $(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/4.9/libs/mips64/libgnustl_static.a
+PLATLDXFLAGS   = -shared --sysroot=$(NDK_ROOT_DIR)/platforms/android-21/arch-mips64 -lgcc -no-canonical-prefixes -Wl,--no-undefined -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -lc -lm $(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/libs/mips64/libgnustl_static.a
 
 ################
 # libretro setup
@@ -86,7 +86,7 @@ endif
 
 CORE_DIR  ?= ..
 BUILD_DIR ?= .
-INCLUDES   = -I$(NDK_ROOT_DIR)/platforms/android-21/arch-mips64/usr/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/4.9/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/4.9/libs/mips64/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/4.9/include/backward
+INCLUDES   = -I$(NDK_ROOT_DIR)/platforms/android-21/arch-mips64/usr/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/libs/mips64/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/include/backward
 
 include $(BUILD_DIR)/Makefile.common
 

--- a/libretro-build/Makefile.android_x86
+++ b/libretro-build/Makefile.android_x86
@@ -24,10 +24,10 @@ TARGET_PLATFORM = android_x86
 #################
 # Toolchain setup
 
-CC  = $(NDK_ROOT_DIR)/toolchains/x86-4.9/prebuilt/$(HOST_PLATFORM)-x86_64/bin/i686-linux-android-gcc
-CXX = $(NDK_ROOT_DIR)/toolchains/x86-4.9/prebuilt/$(HOST_PLATFORM)-x86_64/bin/i686-linux-android-g++
-AS  = $(NDK_ROOT_DIR)/toolchains/x86-4.9/prebuilt/$(HOST_PLATFORM)-x86_64/bin/i686-linux-android-as
-AR  = $(NDK_ROOT_DIR)/toolchains/x86-4.9/prebuilt/$(HOST_PLATFORM)-x86_64/bin/i686-linux-android-ar
+CC  = $(NDK_ROOT_DIR)/toolchains/x86-$(NDK_TOOLCHAIN_VERSION)/prebuilt/$(HOST_PLATFORM)-x86_64/bin/i686-linux-android-gcc
+CXX = $(NDK_ROOT_DIR)/toolchains/x86-$(NDK_TOOLCHAIN_VERSION)/prebuilt/$(HOST_PLATFORM)-x86_64/bin/i686-linux-android-g++
+AS  = $(NDK_ROOT_DIR)/toolchains/x86-$(NDK_TOOLCHAIN_VERSION)/prebuilt/$(HOST_PLATFORM)-x86_64/bin/i686-linux-android-as
+AR  = $(NDK_ROOT_DIR)/toolchains/x86-$(NDK_TOOLCHAIN_VERSION)/prebuilt/$(HOST_PLATFORM)-x86_64/bin/i686-linux-android-ar
 
 ############
 # Extensions
@@ -45,7 +45,7 @@ PLATDEFS       = -DANDROID -DINLINE=inline -DHAVE_STDINT_H -DBSPF_UNIX -DHAVE_IN
 PLATCFLAGS     = -ffunction-sections -funwind-tables -no-canonical-prefixes -fstack-protector -fomit-frame-pointer -fstrict-aliasing -funswitch-loops -finline-limit=300 -Wa,--noexecstack -Wformat -Werror=format-security
 PLATCXXFLAGS   = -ffunction-sections -funwind-tables -no-canonical-prefixes -fstack-protector -fomit-frame-pointer -fstrict-aliasing -funswitch-loops -finline-limit=300 -Wa,--noexecstack -Wformat -Werror=format-security -fno-exceptions -fno-rtti
 PLATLDFLAGS    = -shared --sysroot=$(NDK_ROOT_DIR)/platforms/android-9/arch-x86 -lgcc -no-canonical-prefixes -Wl,--no-undefined -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -lc -lm
-PLATLDXFLAGS   = -shared --sysroot=$(NDK_ROOT_DIR)/platforms/android-9/arch-x86 -lgcc -no-canonical-prefixes -Wl,--no-undefined -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -lc -lm $(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/4.9/libs/x86/libgnustl_static.a
+PLATLDXFLAGS   = -shared --sysroot=$(NDK_ROOT_DIR)/platforms/android-9/arch-x86 -lgcc -no-canonical-prefixes -Wl,--no-undefined -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -lc -lm $(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/libs/x86/libgnustl_static.a
 
 ################
 # libretro setup
@@ -86,7 +86,7 @@ endif
 
 CORE_DIR  ?= ..
 BUILD_DIR ?= .
-INCLUDES   = -I$(NDK_ROOT_DIR)/platforms/android-9/arch-x86/usr/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/4.9/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/4.9/libs/x86/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/4.9/include/backward
+INCLUDES   = -I$(NDK_ROOT_DIR)/platforms/android-9/arch-x86/usr/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/libs/x86/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/include/backward
 
 include $(BUILD_DIR)/Makefile.common
 

--- a/libretro-build/Makefile.android_x86_64
+++ b/libretro-build/Makefile.android_x86_64
@@ -24,10 +24,10 @@ TARGET_PLATFORM = android_x86_64
 #################
 # Toolchain setup
 
-CC  = $(NDK_ROOT_DIR)/toolchains/x86_64-4.9/prebuilt/$(HOST_PLATFORM)-x86_64/bin/x86_64-linux-android-gcc
-CXX = $(NDK_ROOT_DIR)/toolchains/x86_64-4.9/prebuilt/$(HOST_PLATFORM)-x86_64/bin/x86_64-linux-android-g++
-AS  = $(NDK_ROOT_DIR)/toolchains/x86_64-4.9/prebuilt/$(HOST_PLATFORM)-x86_64/bin/x86_64-linux-android-as
-AR  = $(NDK_ROOT_DIR)/toolchains/x86_64-4.9/prebuilt/$(HOST_PLATFORM)-x86_64/bin/x86_64-linux-android-ar
+CC  = $(NDK_ROOT_DIR)/toolchains/x86_64-$(NDK_TOOLCHAIN_VERSION)/prebuilt/$(HOST_PLATFORM)-x86_64/bin/x86_64-linux-android-gcc
+CXX = $(NDK_ROOT_DIR)/toolchains/x86_64-$(NDK_TOOLCHAIN_VERSION)/prebuilt/$(HOST_PLATFORM)-x86_64/bin/x86_64-linux-android-g++
+AS  = $(NDK_ROOT_DIR)/toolchains/x86_64-$(NDK_TOOLCHAIN_VERSION)/prebuilt/$(HOST_PLATFORM)-x86_64/bin/x86_64-linux-android-as
+AR  = $(NDK_ROOT_DIR)/toolchains/x86_64-$(NDK_TOOLCHAIN_VERSION)/prebuilt/$(HOST_PLATFORM)-x86_64/bin/x86_64-linux-android-ar
 
 ############
 # Extensions
@@ -45,7 +45,7 @@ PLATDEFS       = -DANDROID -DINLINE=inline -DHAVE_STDINT_H -DBSPF_UNIX -DHAVE_IN
 PLATCFLAGS     = -ffunction-sections -funwind-tables -fstack-protector -no-canonical-prefixes -fomit-frame-pointer -fstrict-aliasing -funswitch-loops -finline-limit=300 -Wa,--noexecstack -Wformat -Werror=format-security
 PLATCXXFLAGS   = -ffunction-sections -funwind-tables -fstack-protector -no-canonical-prefixes -fomit-frame-pointer -fstrict-aliasing -funswitch-loops -finline-limit=300 -Wa,--noexecstack -Wformat -Werror=format-security -fno-exceptions -fno-rtti
 PLATLDFLAGS    = -shared --sysroot=$(NDK_ROOT_DIR)/platforms/android-21/arch-x86_64 -lgcc -no-canonical-prefixes -Wl,--no-undefined -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -lc -lm
-PLATLDXFLAGS   = -shared --sysroot=$(NDK_ROOT_DIR)/platforms/android-21/arch-x86_64 -lgcc -no-canonical-prefixes -Wl,--no-undefined -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -lc -lm $(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/4.9/libs/x86_64/libgnustl_static.a
+PLATLDXFLAGS   = -shared --sysroot=$(NDK_ROOT_DIR)/platforms/android-21/arch-x86_64 -lgcc -no-canonical-prefixes -Wl,--no-undefined -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -lc -lm $(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/libs/x86_64/libgnustl_static.a
 
 ################
 # libretro setup
@@ -86,7 +86,7 @@ endif
 
 CORE_DIR  ?= ..
 BUILD_DIR ?= .
-INCLUDES   = -I$(NDK_ROOT_DIR)/platforms/android-21/arch-x86_64/usr/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/4.9/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/4.9/libs/x86_64/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/4.9/include/backward
+INCLUDES   = -I$(NDK_ROOT_DIR)/platforms/android-21/arch-x86_64/usr/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/libs/x86_64/include -I$(NDK_ROOT_DIR)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/include/backward
 
 include $(BUILD_DIR)/Makefile.common
 


### PR DESCRIPTION
This downgrades the API level from 21 to 19 for android_armeabi-v7a, which fixes missing symbol errors when loading the cores.