### PR TITLE
Fix crash when changing options in GB/GBC emulation modes

### DIFF
--- a/src/platform/libretro/libretro.c
+++ b/src/platform/libretro/libretro.c
@@ -628,7 +628,12 @@ void retro_run(void) {
 			.value = 0
 		};
 		if (environCallback(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) {
-			((struct GBA*) core->board)->allowOpposingDirections = strcmp(var.value, "yes") == 0;
+			struct GBA* gba = core->board;
+			struct GB* gb = core->board;
+			if (core->platform(core) == PLATFORM_GBA)
+				gba->allowOpposingDirections = strcmp(var.value, "yes") == 0;
+			if (core->platform(core) == PLATFORM_GB)
+				gb->allowOpposingDirections = strcmp(var.value, "yes") == 0;
 		}
 
 		var.key = "mgba_frameskip";


### PR DESCRIPTION
While testing the new color correction code on my Raspberry Pi 3B+ device (armv7-neon), I found out that when you change any core options while emulating a GB/GBC game in contrast to a GBA game, the core segfaults when returning to the emulation, i.e. using Resume from the Quick Menu. This doesn't happen in GBA games.

After inspecting the core dump using a debug build, the culprit is in this line:
https://github.com/libretro/mgba/blob/master/src/platform/libretro/libretro.c#L631

What is happening is that, when emulating non-GBA systems, the `core->board` member should not be casted to `struct GBA*` but to `struct GB*`. To fix this, in this PR I followed the same approach found in the `retro_get_memory_data()` function, where a similar check is done. Now the core doesn't crash and works properly when changing options in GB, GBC or GBA emulated games.

I guess this core is not used very often for emulating GB/GBC games or maybe is specific to the RPI platform, explaining how this wasn't found before :).  I also noticed that the same broken code is in the upstream repository, perhaps this commit should be also ported there (cc @endrift).
