### PR TITLE
Clean up core options

### DIFF
--- a/src/platform/libretro/libretro.h
+++ b/src/platform/libretro/libretro.h
@@ -1169,8 +1169,6 @@ enum retro_mod
                                             * i.e. it should be feasible to cycle through options
                                             * without a keyboard.
                                             *
-                                            * First entry should be treated as a default.
-                                            *
                                             * Example entry:
                                             * {
                                             *     "foo_option",
@@ -2503,9 +2501,7 @@ struct retro_core_option_display
    bool visible;
 };
 
-/* Maximum number of values permitted for a core option
- * NOTE: This may be increased on a core-by-core basis
- * if required (doing so has no effect on the frontend) */
+/* Maximum number of values permitted for a core option */
 #define RETRO_NUM_CORE_OPTION_VALUES_MAX 128
 
 struct retro_core_option_value

--- a/src/platform/libretro/libretro_core_options.h
+++ b/src/platform/libretro/libretro_core_options.h
@@ -27,18 +27,13 @@ extern "C" {
  *   frontend language definition */
 
 struct retro_core_option_definition option_defs_us[] = {
-
-   /* These variable names and possible values constitute an ABI with ZMZ (ZSNES Libretro player).
-    * Changing "Show layer 1" is fine, but don't change "layer_1"/etc or the possible values ("Yes|No").
-    * Adding more variables and rearranging them is safe. */
-
    {
       "mgba_solar_sensor_level",
-      "Solar sensor level",
-      "Can be used by games that employed the use of a solar sensor on their cartridges. E.g: Boktai games.",
+      "Solar Sensor Level",
+      "Sets ambient sunlight intensity. Can be used by games that included a solar sensor in their cartridges, e.g: the Boktai series.",
       {
-         { "0", NULL },
-         { "1", NULL },
+         { "0",  NULL },
+         { "1",  NULL },
          { "2",  NULL },
          { "3",  NULL },
          { "4",  NULL },
@@ -47,96 +42,96 @@ struct retro_core_option_definition option_defs_us[] = {
          { "7",  NULL },
          { "8",  NULL },
          { "9",  NULL },
-         { "10",  NULL },
-         { NULL, NULL},
+         { "10", NULL },
+         { NULL, NULL },
       },
       "0"
    },
    {
       "mgba_allow_opposing_directions",
-      "Allow opposing directional input",
-      "Allows opposing directional inputs. Up with Down. Right with Left.",
+      "Allow Opposing Directional Input",
+      "Enabling this will allow pressing / quickly alternating / holding both left and right (or up and down) directions at the same time. This may cause movement-based glitches.",
       {
-         { "OFF",         "Disabled" },
-         { "ON",          "Enabled" },
-         { NULL, NULL},
+         { "no",  "disabled" },
+         { "yes", "enabled" },
+         { NULL, NULL },
       },
-      "OFF"
+      "no"
    },
    {
       "mgba_gb_model",
-      "Game Boy model (requires restart)",
-      "Runs loaded content with a specific Game Boy model. Autodetect will select the most appropriate model for the current game.",
+      "Game Boy Model (requires restart)",
+      "Runs loaded content with a specific Game Boy model. 'Autodetect' will select the most appropriate model for the current game.",
       {
-         { "Autodetect",     NULL },
-         { "Game Boy",       NULL },
-         { "Super Game Boy", NULL },
-         { "Game Boy Color", NULL},
-         { "Game Boy Advance", NULL},
+         { "Autodetect",       NULL },
+         { "Game Boy",         NULL },
+         { "Super Game Boy",   NULL },
+         { "Game Boy Color",   NULL },
+         { "Game Boy Advance", NULL },
          { NULL, NULL },
       },
       "Autodetect"
    },
    {
       "mgba_use_bios",
-      "Use BIOS file if found (requires restart)",
-      "Uses BIOS present in RetroArch's system directory. Look at the BIOS section for more information.",
+      "Use BIOS File if Found (requires restart)",
+      "Use official BIOS/bootloader for emulated hardware, if present in RetroArch's system directory.",
       {
-         { "ON",  "Enabled" },
-         { "OFF", "Disabled" },
-         { NULL, NULL},
+         { "ON",  NULL },
+         { "OFF", NULL },
+         { NULL, NULL },
       },
       "ON"
    },
    {
       "mgba_skip_bios",
-      "Skip BIOS intro (requires restart)",
-      "The 'Use BIOS file if found' core option must be set to On for proper operation. Skips the BIOS intro when a BIOS is present in RetroArch's system directory is used.",
+      "Skip BIOS Intro (requires restart)",
+      "When using an official BIOS/bootloader, skip the start-up logo animation. This setting is ignored when 'Use BIOS File if Found' is disabled.",
       {
-         { "OFF", "Disabled" },
-         { "ON", "Enabled" },
-         { NULL, NULL},
+         { "OFF", NULL },
+         { "ON",  NULL },
+         { NULL, NULL },
       },
       "OFF"
    },
    {
       "mgba_sgb_borders",
-      "Use Super Game Boy borders (requires restart)",
-      "Display Super Game Boy borders for Super Game Boy enhanced games.",
+      "Use Super Game Boy Borders (requires restart)",
+      "Display Super Game Boy borders when running Super Game Boy enhanced games.",
       {
-         { "ON",   "Enabled" },
-         { "OFF",  "Disabled" },
-         { NULL, NULL},
+         { "ON",  NULL },
+         { "OFF", NULL },
+         { NULL, NULL },
       },
       "ON"
    },
    {
       "mgba_idle_optimization",
-      "Idle loop removal",
-      "Optimizes game performance by driving the GBA's CPU less hard. Use this on low-powered hardware if its struggling with game performance.",
+      "Idle Loop Removal",
+      "Reduce system load by optimizing so-called 'idle-loops' - sections in the code where nothing happens, but the CPU runs at full speed (like a car revving in neutral). Improves performance, and should be enabled on low-end hardware.",
       {
-         { "Remove Known", NULL },
+         { "Remove Known",      NULL },
          { "Detect and Remove", NULL },
-         { "Don't Remove", NULL },
-         { NULL, NULL},
+         { "Don't Remove",      NULL },
+         { NULL, NULL },
       },
       "Remove Known"
    },
    {
       "mgba_frameskip",
       "Frameskip",
-      "Choose how much frames should be skipped to improve performance at the expense of visual smoothness.",
+      "Skip frames to improve performance at the expense of visual smoothness. Value set here is the number of frames omitted after a frame is rendered - i.e. '0' = 60fps, '1' = 30fps, '2' = 15fps, etc.",
       {
-         { "0", NULL },
-         { "1", NULL },
-         { "2", NULL },
-         { "3", NULL },
-         { "4", NULL },
-         { "5", NULL },
-         { "6", NULL },
-         { "7", NULL },
-         { "8", NULL },
-         { "9", NULL },
+         { "0",  NULL },
+         { "1",  NULL },
+         { "2",  NULL },
+         { "3",  NULL },
+         { "4",  NULL },
+         { "5",  NULL },
+         { "6",  NULL },
+         { "7",  NULL },
+         { "8",  NULL },
+         { "9",  NULL },
          { "10", NULL },
          { NULL, NULL },
       },
@@ -146,13 +141,13 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "mgba_color_correction",
       "Color Correction",
-      "Awaiting description",
+      "Adjusts output colors to match the display of real GBA/GBC hardware.",
       {
          { "OFF",  NULL },
          { "GBA",  "Game Boy Advance" },
          { "GBC",  "Game Boy Color" },
-         { "Auto",  NULL },
-         { NULL, NULL},
+         { "Auto", NULL },
+         { NULL, NULL },
       },
       "OFF"
    },
@@ -196,664 +191,6 @@ struct retro_core_option_definition option_defs_us[] = {
 
 /* RETRO_LANGUAGE_TURKISH */
 
-struct retro_core_option_definition option_defs_tr[] = {
-
-   /* These variable names and possible values constitute an ABI with ZMZ (ZSNES Libretro player).
-    * Changing "Show layer 1" is fine, but don't change "layer_1"/etc or the possible values ("Yes|No").
-    * Adding more variables and rearranging them is safe. */
-      {
-      "snes9x_region",
-      "Konsol Bölgesi (Core Yenilenir)",
-      "Sistemin hangi bölgeden olduğunu belirtir.. 'PAL' 50hz'dir, 'NTSC' ise 60hz. Yanlış bölge seçiliyse, oyunlar normalden daha hızlı veya daha yavaş çalışacaktır.",
-      {
-         { "auto", "Otomatik" },
-         { "ntsc", "NTSC" },
-         { "pal",  "PAL" },
-         { NULL, NULL},
-      },
-      "auto"
-   },
-   {
-      "snes9x_aspect",
-      "Tercih Edilen En Boy Oranı",
-      "Tercih edilen içerik en boy oranını seçin. Bu, yalnızca RetroArch’ın en boy oranı Video ayarlarında 'Core tarafından' olarak ayarlandığında uygulanacaktır.",
-      {
-         { "4:3",         NULL },
-         { "uncorrected", "Düzeltilmemiş" },
-         { "auto",        "Otomatik" },
-         { "ntsc",        "NTSC" },
-         { "pal",         "PAL" },
-         { NULL, NULL},
-      },
-      "4:3"
-   },
-   {
-      "snes9x_overscan",
-      "Aşırı Taramayı Kırp",
-      "Ekranın üst ve alt kısmındaki ~8 piksel sınırlarını, tipik olarak standart çözünürlüklü bir televizyondakini kaldırır. 'Otomatik' ise geçerli içeriğe bağlı olarak aşırı taramayı algılamaya ve kırpmaya çalışacaktır.",
-      {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { "auto",     "Otomatik" },
-         { NULL, NULL},
-      },
-      "enabled"
-   },
-   {
-      "snes9x_gfx_hires",
-      "Hi-Res Modunu Etkinleştir",
-      "Oyunların hi-res moduna (512x448) geçmesine izin verir veya tüm içeriği 256x224'te (ezilmiş piksellerle) çıkmaya zorlar.",
-      {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL},
-      },
-      "enabled"
-   },
-   {
-      "snes9x_hires_blend",
-      "Hi-Res Karışımı",
-      "Oyun hi-res moduna geçtiğinde pikselleri karıştırır (512x448). Şeffaflık efektleri üretmek için hi-res modunu kullanan bazı oyunlar için gereklidir (Kirby's Dream Land, Jurassic Park ...).",
-      {
-         { "disabled", NULL },
-         { "merge",    "Birlşetir" },
-         { "blur",     "Bulanıklaştır" },
-         { NULL, NULL},
-      },
-      "disabled"
-   },
-   {
-      "snes9x_blargg",
-      "Blargg NTSC Filtresi",
-      "Çeşitli NTSC TV sinyallerini taklit etmek için bir video filtresi uygular.",
-      {
-         { "disabled",   NULL },
-         { "monochrome", "Monochrome" },
-         { "rf",         "RF" },
-         { "composite",  "Composite" },
-         { "s-video",    "S-Video" },
-         { "rgb",        "RGB" },
-         { NULL, NULL},
-      },
-      "disabled"
-   },
-   {
-      "snes9x_audio_interpolation",
-      "Ses Enterpolasyonu",
-      "Belirtilen ses filtresini uygular. 'Gaussian', orijinal donanımın bas ağırlıklı sesini üretir. 'Cubic' ve 'Sinc' daha az doğrudur ve daha fazla aralığı korur.",
-      {
-         { "gaussian", "Gaussian" },
-         { "cubic",    "Cubic" },
-         { "sinc",     "Sinc" },
-         { "none",     "Hiçbiri" },
-         { "linear",   "Linear" },
-         { NULL, NULL},
-      },
-      "gaussian"
-   },
-   {
-      "snes9x_up_down_allowed",
-      "Karşı Yönlere İzin Ver",
-      "Bunu etkinleştirmek aynı anda hem sola hem de sağa (veya yukarı ve aşağı) yönlere basma / hızlı değiştirme / tutma imkanı sağlar. Bu harekete dayalı hatalara neden olabilir.",
-      {
-         { "disabled", NULL },
-         { "enabled",  NULL },
-         { NULL, NULL },
-      },
-      "disabled"
-   },
-   {
-      "snes9x_overclock_superfx",
-      "SuperFX Hız Aşırtma",
-      "SuperFX işlemcisi frekans çarpanıdır. Kare hızını artırabilir veya zamanlama hatalarına neden olabilir. % 100'ün altındaki değerler yavaş cihazlarda oyun performansını artırabilir.",
-      {
-         { "50%",  NULL },
-         { "60%",  NULL },
-         { "70%",  NULL },
-         { "80%",  NULL },
-         { "90%",  NULL },
-         { "100%", NULL },
-         { "150%", NULL },
-         { "200%", NULL },
-         { "250%", NULL },
-         { "300%", NULL },
-         { "350%", NULL },
-         { "400%", NULL },
-         { "450%", NULL },
-         { "500%", NULL },
-         { NULL, NULL},
-      },
-      "100%"
-   },
-   {
-      "snes9x_overclock_cycles",
-      "Yavaşlamayı Azalt (Hack, Güvensiz)",
-      "SNES İşlemcisi için hız aşırtmadır. Oyunların çökmesine neden olabilir! Daha kısa yükleme süreleri için 'Hafif'i, yavaşlama gösteren oyunların çoğunda' Uyumlu 've yalnızca kesinlikle gerekliyse' Maks 'kullanın (Gradius 3, Süper R tipi ...).",
-      {
-         { "disabled",   NULL },
-         { "light",      "Hafif" },
-         { "compatible", "Uyumlu" },
-         { "max",        "Maks" },
-         { NULL, NULL},
-      },
-      "disabled"
-   },
-   {
-      "snes9x_reduce_sprite_flicker",
-      "Kırılmayı Azalt (Hack, Güvensiz)",
-      "Ekranda aynı anda çizilebilen sprite sayısını arttırır.",
-      {
-         { "disabled", NULL },
-         { "enabled",  NULL },
-         { NULL, NULL},
-      },
-      "disabled"
-   },
-   {
-      "snes9x_randomize_memory",
-      "Belleği Rastgele Kıl (Güvensiz)",
-      "Başlatıldığında sistem RAM'ını rastgele ayarlar. 'Super Off Road' gibi bazı oyunlar, oyunu daha öngörülemeyen hale getirmek için öğe yerleştirme ve AI davranışı için rastgele sayı üreticisi olarak sistem RAM'ini kullanır.",
-      {
-         { "disabled", NULL },
-         { "enabled",  NULL },
-         { NULL, NULL},
-      },
-      "disabled"
-   },
-   {
-      "snes9x_block_invalid_vram_access",
-      "Geçersiz VRAM Erişimini Engelle",
-      "Bazı Homebrew/ROM'lar, doğru işlem için bu seçeneğin devre dışı bırakılmasını gerektirir.",
-      {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL},
-      },
-      "enabled"
-   },
-   {
-      "snes9x_echo_buffer_hack",
-      "Eko Tampon Hack (Güvenli değil, yalnızca eski addmusic için etkinleştirin)",
-      "Bazı Homebrew/ROM'lar, doğru işlem için bu seçeneğin devre dışı bırakılmasını gerektirir.",
-      {
-         { "disabled", NULL },
-         { "enabled",  NULL },
-         { NULL, NULL},
-      },
-      "disabled"
-   },
-   {
-      "snes9x_show_lightgun_settings",
-      "Light Gun Ayarlarını Göster",
-      "Super Scope / Justifier / M.A.C.S. için tüfek girişi yapılandırmasını etkinleştir. NOT: Bu ayarın etkili olabilmesi için Hızlı Menü’nün açılması gerekir.",
-      {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL},
-      },
-      "disabled"
-   },
-   {
-      "snes9x_lightgun_mode",
-      "Light Gun Modu",
-      "Fare kontrollü 'Light Gun' veya 'Dokunmatik Ekran' girişini kullanın.",
-      {
-         { "Lightgun",    "Light Gun" },
-         { "Touchscreen", "Dokunmatik Ekran" },
-         { NULL, NULL},
-      },
-      "Lightgun"
-   },
-   {
-      "snes9x_superscope_reverse_buttons",
-      "Super Scope Ters Tetik Düğmeleri",
-      "Süper Scope için 'Ateş' ve 'İmleç' butonlarının pozisyonlarını değiştir.",
-      {
-         { "disabled", NULL },
-         { "enabled",  NULL },
-         { NULL, NULL},
-      },
-      "disabled"
-   },
-   {
-      "snes9x_superscope_crosshair",
-      "Super Scope İmkeç",
-      "Ekrandaki imleç işaretini değiştirin.",
-      {
-         { "0",  NULL },
-         { "1",  NULL },
-         { "2",  NULL },
-         { "3",  NULL },
-         { "4",  NULL },
-         { "5",  NULL },
-         { "6",  NULL },
-         { "7",  NULL },
-         { "8",  NULL },
-         { "9",  NULL },
-         { "10", NULL },
-         { "11", NULL },
-         { "12", NULL },
-         { "13", NULL },
-         { "14", NULL },
-         { "15", NULL },
-         { "16", NULL },
-         { NULL, NULL},
-      },
-      "2"
-   },
-   {
-      "snes9x_superscope_color",
-      "Super Scope Rengi",
-      "Ekrandaki imleç işaretinin rengini değiştirin.",
-      {
-         { "White",            NULL },
-         { "White (blend)",    NULL },
-         { "Red",              NULL },
-         { "Red (blend)",      NULL },
-         { "Orange",           NULL },
-         { "Orange (blend)",   NULL },
-         { "Yellow",           NULL },
-         { "Yellow (blend)",   NULL },
-         { "Green",            NULL },
-         { "Green (blend)",    NULL },
-         { "Cyan",             NULL },
-         { "Cyan (blend)",     NULL },
-         { "Sky",              NULL },
-         { "Sky (blend)",      NULL },
-         { "Blue",             NULL },
-         { "Blue (blend)",     NULL },
-         { "Violet",           NULL },
-         { "Violet (blend)",   NULL },
-         { "Pink",             NULL },
-         { "Pink (blend)",     NULL },
-         { "Purple",           NULL },
-         { "Purple (blend)",   NULL },
-         { "Black",            NULL },
-         { "Black (blend)",    NULL },
-         { "25% Grey",         NULL },
-         { "25% Grey (blend)", NULL },
-         { "50% Grey",         NULL },
-         { "50% Grey (blend)", NULL },
-         { "75% Grey",         NULL },
-         { "75% Grey (blend)", NULL },
-         { NULL, NULL},
-      },
-      "White"
-   },
-   {
-      "snes9x_justifier1_crosshair",
-      "Justifier 1 İmleci",
-      "Ekrandaki imleç işaretinin boyutunu değiştirin.",
-      {
-         { "0",  NULL },
-         { "1",  NULL },
-         { "2",  NULL },
-         { "3",  NULL },
-         { "4",  NULL },
-         { "5",  NULL },
-         { "6",  NULL },
-         { "7",  NULL },
-         { "8",  NULL },
-         { "9",  NULL },
-         { "10", NULL },
-         { "11", NULL },
-         { "12", NULL },
-         { "13", NULL },
-         { "14", NULL },
-         { "15", NULL },
-         { "16", NULL },
-         { NULL, NULL},
-      },
-      "4"
-   },
-   {
-      "snes9x_justifier1_color",
-      "Justifier 1 Rengi",
-      "Ekrandaki imleç işaretinin rengini değiştirin.",
-      {
-         { "Blue",             NULL },
-         { "Blue (blend)",     NULL },
-         { "Violet",           NULL },
-         { "Violet (blend)",   NULL },
-         { "Pink",             NULL },
-         { "Pink (blend)",     NULL },
-         { "Purple",           NULL },
-         { "Purple (blend)",   NULL },
-         { "Black",            NULL },
-         { "Black (blend)",    NULL },
-         { "25% Grey",         NULL },
-         { "25% Grey (blend)", NULL },
-         { "50% Grey",         NULL },
-         { "50% Grey (blend)", NULL },
-         { "75% Grey",         NULL },
-         { "75% Grey (blend)", NULL },
-         { "White",            NULL },
-         { "White (blend)",    NULL },
-         { "Red",              NULL },
-         { "Red (blend)",      NULL },
-         { "Orange",           NULL },
-         { "Orange (blend)",   NULL },
-         { "Yellow",           NULL },
-         { "Yellow (blend)",   NULL },
-         { "Green",            NULL },
-         { "Green (blend)",    NULL },
-         { "Cyan",             NULL },
-         { "Cyan (blend)",     NULL },
-         { "Sky",              NULL },
-         { "Sky (blend)",      NULL },
-         { NULL, NULL},
-      },
-      "Blue"
-   },
-   {
-      "snes9x_justifier2_crosshair",
-      "Justifier 2 İmleci",
-      "Ekrandaki imleç işaretinin boyutunu değiştirin.",
-      {
-         { "0",  NULL },
-         { "1",  NULL },
-         { "2",  NULL },
-         { "3",  NULL },
-         { "4",  NULL },
-         { "5",  NULL },
-         { "6",  NULL },
-         { "7",  NULL },
-         { "8",  NULL },
-         { "9",  NULL },
-         { "10", NULL },
-         { "11", NULL },
-         { "12", NULL },
-         { "13", NULL },
-         { "14", NULL },
-         { "15", NULL },
-         { "16", NULL },
-         { NULL, NULL},
-      },
-      "4"
-   },
-   {
-      "snes9x_justifier2_color",
-      "Justifier 2 REngi",
-      "Ekrandaki imleç işaretinin rengini değiştirin.",
-      {
-         { "Pink",             NULL },
-         { "Pink (blend)",     NULL },
-         { "Purple",           NULL },
-         { "Purple (blend)",   NULL },
-         { "Black",            NULL },
-         { "Black (blend)",    NULL },
-         { "25% Grey",         NULL },
-         { "25% Grey (blend)", NULL },
-         { "50% Grey",         NULL },
-         { "50% Grey (blend)", NULL },
-         { "75% Grey",         NULL },
-         { "75% Grey (blend)", NULL },
-         { "White",            NULL },
-         { "White (blend)",    NULL },
-         { "Red",              NULL },
-         { "Red (blend)",      NULL },
-         { "Orange",           NULL },
-         { "Orange (blend)",   NULL },
-         { "Yellow",           NULL },
-         { "Yellow (blend)",   NULL },
-         { "Green",            NULL },
-         { "Green (blend)",    NULL },
-         { "Cyan",             NULL },
-         { "Cyan (blend)",     NULL },
-         { "Sky",              NULL },
-         { "Sky (blend)",      NULL },
-         { "Blue",             NULL },
-         { "Blue (blend)",     NULL },
-         { "Violet",           NULL },
-         { "Violet (blend)",   NULL },
-         { NULL, NULL},
-      },
-      "Pink"
-   },
-   {
-      "snes9x_rifle_crosshair",
-      "M.A.C.S. Tüfek ",
-      "Ekrandaki imleç işaretinin rengini değiştirin..",
-      {
-         { "0",  NULL },
-         { "1",  NULL },
-         { "2",  NULL },
-         { "3",  NULL },
-         { "4",  NULL },
-         { "5",  NULL },
-         { "6",  NULL },
-         { "7",  NULL },
-         { "8",  NULL },
-         { "9",  NULL },
-         { "10", NULL },
-         { "11", NULL },
-         { "12", NULL },
-         { "13", NULL },
-         { "14", NULL },
-         { "15", NULL },
-         { "16", NULL },
-         { NULL, NULL},
-      },
-      "2"
-   },
-   {
-      "snes9x_rifle_color",
-      "M.A.C.S. Tüfek Rengi",
-      "Ekrandaki imleç işaretinin rengini değiştirin.",
-      {
-         { "White",            NULL },
-         { "White (blend)",    NULL },
-         { "Red",              NULL },
-         { "Red (blend)",      NULL },
-         { "Orange",           NULL },
-         { "Orange (blend)",   NULL },
-         { "Yellow",           NULL },
-         { "Yellow (blend)",   NULL },
-         { "Green",            NULL },
-         { "Green (blend)",    NULL },
-         { "Cyan",             NULL },
-         { "Cyan (blend)",     NULL },
-         { "Sky",              NULL },
-         { "Sky (blend)",      NULL },
-         { "Blue",             NULL },
-         { "Blue (blend)",     NULL },
-         { "Violet",           NULL },
-         { "Violet (blend)",   NULL },
-         { "Pink",             NULL },
-         { "Pink (blend)",     NULL },
-         { "Purple",           NULL },
-         { "Purple (blend)",   NULL },
-         { "Black",            NULL },
-         { "Black (blend)",    NULL },
-         { "25% Grey",         NULL },
-         { "25% Grey (blend)", NULL },
-         { "50% Grey",         NULL },
-         { "50% Grey (blend)", NULL },
-         { "75% Grey",         NULL },
-         { "75% Grey (blend)", NULL },
-         { NULL, NULL},
-      },
-      "White"
-   },
-   {
-      "snes9x_show_advanced_av_settings",
-      "Gelişmiş Ses/Video Ayarlarını Göster",
-      "Düşük seviye video katmanı / GFX etkisi / ses kanalı parametrelerinin yapılandırılmasını etkinleştirir. NOT: Bu ayarın etkili olabilmesi için Hızlı Menü’nün açılması gerekir.",
-      {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL},
-      },
-      "disabled"
-   },
-   {
-      "snes9x_layer_1",
-      "1. Katmanı Göster",
-      NULL,
-      {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL},
-      },
-      "enabled"
-   },
-   {
-      "snes9x_layer_2",
-      "2. Katmanı Göster",
-      NULL,
-      {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL},
-      },
-      "enabled"
-   },
-   {
-      "snes9x_layer_3",
-      "3. Katmanı Göster",
-      NULL,
-      {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL},
-      },
-      "enabled"
-   },
-   {
-      "snes9x_layer_4",
-      "4. Katmanı Göster",
-      NULL,
-      {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL},
-      },
-      "enabled"
-   },
-   {
-      "snes9x_layer_5",
-      "Sprite Katmanını Göster",
-      NULL,
-      {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL},
-      },
-      "enabled"
-   },
-   {
-      "snes9x_gfx_clip",
-      "Grafik Klibi Pencerelerini Etkinleştir",
-      NULL,
-      {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL},
-      },
-      "enabled"
-   },
-   {
-      "snes9x_gfx_transp",
-      "Saydamlık Efektlerini Etkinleştir",
-      NULL,
-      {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL},
-      },
-      "enabled"
-   },
-   {
-      "snes9x_sndchan_1",
-      "Ses Kanalı 1'i etkinleştir",
-      NULL,
-      {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL},
-      },
-      "enabled"
-   },
-   {
-      "snes9x_sndchan_2",
-      "Ses Kanalı 2'yi etkinleştir",
-      NULL,
-      {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL},
-      },
-      "enabled"
-   },
-   {
-      "snes9x_sndchan_3",
-      "Ses Kanalı 3'ü etkinleştir",
-      NULL,
-      {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL},
-      },
-      "enabled"
-   },
-   {
-      "snes9x_sndchan_4",
-      "Ses Kanalı 4'ü etkinleştir",
-      NULL,
-      {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL},
-      },
-      "enabled"
-   },
-   {
-      "snes9x_sndchan_5",
-      "Ses Kanalı 5'i etkinleştir",
-      NULL,
-      {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL},
-      },
-      "enabled"
-   },
-   {
-      "snes9x_sndchan_6",
-      "Ses Kanalı 6'yı etkinleştir",
-      NULL,
-      {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL},
-      },
-      "enabled"
-   },
-   {
-      "snes9x_sndchan_7",
-      "Ses Kanalı 7'yi etkinleştir",
-      NULL,
-      {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL},
-      },
-      "enabled"
-   },
-   {
-      "snes9x_sndchan_8",
-      "Ses Kanalı 8'i etkinleştir",
-      NULL,
-      {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL},
-      },
-      "enabled"
-   },
-   { NULL, NULL, NULL, {{0}}, NULL },
-};
-
 /*
  ********************************
  * Language Mapping
@@ -879,7 +216,7 @@ struct retro_core_option_definition *option_defs_intl[RETRO_LANGUAGE_LAST] = {
    NULL,           /* RETRO_LANGUAGE_VIETNAMESE */
    NULL,           /* RETRO_LANGUAGE_ARABIC */
    NULL,           /* RETRO_LANGUAGE_GREEK */
-   option_defs_tr, /* RETRO_LANGUAGE_TURKISH */
+   NULL,           /* RETRO_LANGUAGE_TURKISH */
 };
 
 /*
@@ -889,7 +226,8 @@ struct retro_core_option_definition *option_defs_intl[RETRO_LANGUAGE_LAST] = {
 */
 
 /* Handles configuration/setting of core options.
- * Should only be called inside retro_set_environment().
+ * Should be called as early as possible - ideally inside
+ * retro_set_environment(), and no later than retro_load_game()
  * > We place the function body in the header to avoid the
  *   necessity of adding more .c files (i.e. want this to
  *   be as painless as possible for core devs)
@@ -919,17 +257,11 @@ static INLINE void libretro_set_core_options(retro_environment_t environ_cb)
    else
    {
       size_t i;
-      size_t option_index              = 0;
       size_t num_options               = 0;
       struct retro_variable *variables = NULL;
       char **values_buf                = NULL;
 
-      /* Determine number of options
-       * > Note: We are going to skip a number of irrelevant
-       *   core options when building the retro_variable array,
-       *   but we'll allocate space for all of them. The difference
-       *   in resource usage is negligible, and this allows us to
-       *   keep the code 'cleaner' */
+      /* Determine number of options */
       while (true)
       {
          if (option_defs_us[num_options].key)
@@ -956,12 +288,6 @@ static INLINE void libretro_set_core_options(retro_environment_t environ_cb)
          size_t default_index                   = 0;
 
          values_buf[i] = NULL;
-
-         /* Skip options that are irrelevant when using the
-          * old style core options interface */
-         if ((strcmp(key, "snes9x_show_lightgun_settings") == 0) ||
-             (strcmp(key, "snes9x_show_advanced_av_settings") == 0))
-            continue;
 
          if (desc)
          {
@@ -1014,9 +340,8 @@ static INLINE void libretro_set_core_options(retro_environment_t environ_cb)
             }
          }
 
-         variables[option_index].key   = key;
-         variables[option_index].value = values_buf[i];
-         option_index++;
+         variables[i].key   = key;
+         variables[i].value = values_buf[i];
       }
       
       /* Set variables */


### PR DESCRIPTION
This PR makes the following improvements to the 'enhanced' core options:

- A whole bunch of stuff erroneously copied from snes9x has been removed

- Unnecessary value labels have been removed

- Sublabel text has been improved

This also fixes what seems to an old bug, where the `mgba_allow_opposing_directions` option has the wrong values (should be yes/no instead of ON/OFF)