### PR TITLE
Add optional interframe blending

### DIFF
--- a/src/platform/libretro/libretro_core_options.h
+++ b/src/platform/libretro/libretro_core_options.h
@@ -173,6 +173,19 @@ struct retro_core_option_definition option_defs_us[] = {
       },
       "OFF"
    },
+   {
+      "mgba_interframe_blending",
+      "Interframe Blending",
+      "Simulates LCD ghosting effects. 'Simple' performs a 50:50 mix of the current and previous frames. 'Smart' attempts to detect screen flickering, and only performs a 50:50 mix on affected pixels. 'LCD Ghosting' mimics natural LCD response times by combining multiple buffered frames. 'Simple' or 'Smart' blending is required when playing games that aggressively exploit LCD ghosting for transparency effects (Wave Race, Chikyuu Kaihou Gun ZAS, F-Zero, the Boktai series...).",
+      {
+         { "OFF",          NULL },
+         { "mix",          "Simple" },
+         { "mix_smart",    "Smart" },
+         { "lcd_ghosting", "LCD Ghosting" },
+         { NULL, NULL },
+      },
+      "OFF"
+   },
 #endif
    { NULL, NULL, NULL, {{0}}, NULL },
 };


### PR DESCRIPTION
This PR adds a new `Interframe Blending` core option. This simulates LCD ghosting by mixing the current and previous frames. This is required for correct rendering of games that 'abuse' the slow response time of the GB/GBC/GBA LCD panel to create transparency and/or antialiasing effects. Notable games affected by this are Wave Race on the GB and the F-Zero/Golden Sun/Boktai games on GBA.

Three settings are provided:

- `Simple`: This performs a blanket 50:50 mix of the current and previous frame

- `Smart`: This does the same as `Simple`, but it attempts to detect flickering and only mixes affected pixels. This, for example, allows F-Zero to be played with a correctly transparent map, but without blurring the entire screen.

- `LCD Ghosting`: This blends multiple buffered frames to create a 'natural' LCD response. This produces a similar effect to standard LCD-blur-type GPU shaders

`Simple` and `Smart` are best used with games that rely on slow LCD response times for transparency effects (these effects are quite 'aggressive', and dumb 50:50 blending is often the only way to deal with them). `LCD Ghosting` is more of a 'prettification' effect, for general use.

Note that all these effects are generated in software, and are therefore somewhat slow. This is probably not much of an issue on any platform that can run mGBA full speed (but `LCD Ghosting` may be a bit heavy for e.g. some Android devices)

This closes #143