### PR TITLE
Add 'fast' variants of interframe blending methods

### DIFF
--- a/src/platform/libretro/libretro_core_options.h
+++ b/src/platform/libretro/libretro_core_options.h
@@ -178,10 +178,13 @@ struct retro_core_option_definition option_defs_us[] = {
       "Interframe Blending",
       "Simulates LCD ghosting effects. 'Simple' performs a 50:50 mix of the current and previous frames. 'Smart' attempts to detect screen flickering, and only performs a 50:50 mix on affected pixels. 'LCD Ghosting' mimics natural LCD response times by combining multiple buffered frames. 'Simple' or 'Smart' blending is required when playing games that aggressively exploit LCD ghosting for transparency effects (Wave Race, Chikyuu Kaihou Gun ZAS, F-Zero, the Boktai series...).",
       {
-         { "OFF",          NULL },
-         { "mix",          "Simple" },
-         { "mix_smart",    "Smart" },
-         { "lcd_ghosting", "LCD Ghosting" },
+         { "OFF",               NULL },
+         { "mix",               "Simple (Accurate)" },
+         { "mix_fast",          "Simple (Fast)" },
+         { "mix_smart",         "Smart (Accurate)" },
+         { "mix_smart_fast",    "Smart (Fast)" },
+         { "lcd_ghosting",      "LCD Ghosting (Accurate)" },
+         { "lcd_ghosting_fast", "LCD Ghosting (Fast)" },
          { NULL, NULL },
       },
       "OFF"


### PR DESCRIPTION
This PR adds 'fast' variants of the interframe blending effects. These trade accuracy and/or quality for performance.

- The `Simple (Fast)` and `Smart (Fast)` methods use bit twiddling to mix frames. This is highly efficient, but causes slight darkening of colours (due to rounding errors)

- The `LCD Ghosting (Fast)` effect uses a single (well, three component) persistent RGB accumulation buffer instead of sampling/processing five distinct frames. This produces a 'grungier' effect (but I guess some may prefer this)

Here are some stats showing the typical increase in performance overheads when using the various methods:

- `Simple (Accurate)`: 25%
- `Simple (Fast)`: 9%
- `Smart (Accurate)`: 9% (note - highly dependent on screen contents)
- `Smart (Fast)`: 7% (note - highly dependent on screen contents)
- `LCD Ghosting (Accurate)`: 42%
- `LCD Ghosting (Fast)`: 25%
