### PR TITLE
Fix the libretro 3DS build

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -297,6 +297,7 @@ else ifeq ($(platform), ctr)
    CC = $(DEVKITARM)/bin/arm-none-eabi-gcc$(EXE_EXT)
    AR = $(DEVKITARM)/bin/arm-none-eabi-ar$(EXE_EXT)
    PLATFORM_DEFINES := -DARM11 -D_3DS
+	 PLATFORM_DEFINES += -DHAVE_STRTOF_L -DHAVE_LOCALE -D_GNU_SOURCE
 
    CFLAGS += -march=armv6k -mtune=mpcore -mfloat-abi=hard
    CFLAGS += -Wall -mword-relocations

--- a/libretro-build/Makefile.common
+++ b/libretro-build/Makefile.common
@@ -121,10 +121,6 @@ ifeq ($(STATIC_LINKING), 1)
 RETRODEFS += -DHAVE_CRC32
 endif
 
-ifeq ($(platform), ctr)
-SOURCES_C += $(CORE_DIR)/src/platform/3ds/ctru-heap.c
-endif
-
 ifeq ($(HAVE_NEON),1)
 SOURCES_ASM += $(CORE_DIR)/src/util/arm-algo.S
 endif


### PR DESCRIPTION
strtof_l was being defined twice -- the 3DS toolchain already has a copy, so we should use that one.

The RetroArch frontend already does memory allocation, and the code in ctru-heap was conflicting with it, so ctru-heap is now being skipped.

This runs more slowly in RetroArch than the standalone mgba build. Threaded video in mgba accounts for about a third of the difference, I haven't figured out any other hints.