### PR TITLE
Update colour correction parameters

### DIFF
--- a/src/platform/libretro/libretro.c
+++ b/src/platform/libretro/libretro.c
@@ -103,27 +103,32 @@ static u32 hidSixAxisHandles[4];
 #define CC_TARGET_GAMMA   2.2f
 #define CC_RGB_MAX        31.0f
 
-#define GBC_CC_R          0.87f
-#define GBC_CC_G          0.66f
-#define GBC_CC_B          0.79f
-#define GBC_CC_RG         0.115f
-#define GBC_CC_RB         0.14f
-#define GBC_CC_GR         0.18f
-#define GBC_CC_GB         0.07f
-#define GBC_CC_BR        -0.05f
-#define GBC_CC_BG         0.225f
+/* > Note: GBC and GBA share almost identical
+ *   colour space, but we maintain independent
+ *   values in case of future adjustments */
+#define GBC_CC_LUM        0.94f
+#define GBC_CC_R          0.82f
+#define GBC_CC_G          0.665f
+#define GBC_CC_B          0.73f
+#define GBC_CC_RG         0.125f
+#define GBC_CC_RB         0.195f
+#define GBC_CC_GR         0.24f
+#define GBC_CC_GB         0.075f
+#define GBC_CC_BR        -0.06f
+#define GBC_CC_BG         0.21f
 #define GBC_CC_GAMMA_ADJ -0.5f
 
-#define GBA_CC_R          0.86f
-#define GBA_CC_G          0.66f
-#define GBA_CC_B          0.81f
-#define GBA_CC_RG         0.11f
-#define GBA_CC_RB         0.1325f
-#define GBA_CC_GR         0.19f
-#define GBA_CC_GB         0.0575f
-#define GBA_CC_BR        -0.05f
-#define GBA_CC_BG         0.23f
-#define GBA_CC_GAMMA_ADJ  0.45f
+#define GBA_CC_LUM        0.94f
+#define GBA_CC_R          0.82f
+#define GBA_CC_G          0.665f
+#define GBA_CC_B          0.73f
+#define GBA_CC_RG         0.125f
+#define GBA_CC_RB         0.195f
+#define GBA_CC_GR         0.24f
+#define GBA_CC_GB         0.075f
+#define GBA_CC_BR        -0.06f
+#define GBA_CC_BG         0.21f
+#define GBA_CC_GAMMA_ADJ  1.0f
 
 static color_t* ccLUT              = NULL;
 static unsigned ccType             = 0;
@@ -137,6 +142,7 @@ static void _initColorCorrection(void) {
 
 	/* Variables */
 	enum GBModel model = GB_MODEL_AUTODETECT;
+	float ccLum;
 	float ccR;
 	float ccG;
 	float ccB;
@@ -196,27 +202,29 @@ static void _initColorCorrection(void) {
 
 	switch (model) {
 		case GB_MODEL_AGB:
-			ccR  = GBA_CC_R;
-			ccG  = GBA_CC_G;
-			ccB  = GBA_CC_B;
-			ccRG = GBA_CC_RG;
-			ccRB = GBA_CC_RB;
-			ccGR = GBA_CC_GR;
-			ccGB = GBA_CC_GB;
-			ccBR = GBA_CC_BR;
-			ccBG = GBA_CC_BG;
+			ccLum = GBA_CC_LUM;
+			ccR   = GBA_CC_R;
+			ccG   = GBA_CC_G;
+			ccB   = GBA_CC_B;
+			ccRG  = GBA_CC_RG;
+			ccRB  = GBA_CC_RB;
+			ccGR  = GBA_CC_GR;
+			ccGB  = GBA_CC_GB;
+			ccBR  = GBA_CC_BR;
+			ccBG  = GBA_CC_BG;
 			adjustedGamma = CC_TARGET_GAMMA + GBA_CC_GAMMA_ADJ;
 			break;
 		case GB_MODEL_CGB:
-			ccR  = GBC_CC_R;
-			ccG  = GBC_CC_G;
-			ccB  = GBC_CC_B;
-			ccRG = GBC_CC_RG;
-			ccRB = GBC_CC_RB;
-			ccGR = GBC_CC_GR;
-			ccGB = GBC_CC_GB;
-			ccBR = GBC_CC_BR;
-			ccBG = GBC_CC_BG;
+			ccLum = GBC_CC_LUM;
+			ccR   = GBC_CC_R;
+			ccG   = GBC_CC_G;
+			ccB   = GBC_CC_B;
+			ccRG  = GBC_CC_RG;
+			ccRB  = GBC_CC_RB;
+			ccGR  = GBC_CC_GR;
+			ccGB  = GBC_CC_GB;
+			ccBR  = GBC_CC_BR;
+			ccBG  = GBC_CC_BG;
 			adjustedGamma = CC_TARGET_GAMMA + GBC_CC_GAMMA_ADJ;
 			break;
 		default:
@@ -254,9 +262,9 @@ static void _initColorCorrection(void) {
 		float gFloat = pow((float)g * rgbMaxInv, adjustedGamma);
 		float bFloat = pow((float)b * rgbMaxInv, adjustedGamma);
 		/* Perform colour mangling */
-		float rCorrect = (ccR  * rFloat) + (ccGR * gFloat) + (ccBR * bFloat);
-		float gCorrect = (ccRG * rFloat) + (ccG  * gFloat) + (ccBG * bFloat);
-		float bCorrect = (ccRB * rFloat) + (ccGB * gFloat) + (ccB  * bFloat);
+		float rCorrect = ccLum * ((ccR  * rFloat) + (ccGR * gFloat) + (ccBR * bFloat));
+		float gCorrect = ccLum * ((ccRG * rFloat) + (ccG  * gFloat) + (ccBG * bFloat));
+		float bCorrect = ccLum * ((ccRB * rFloat) + (ccGB * gFloat) + (ccB  * bFloat));
 		/* Range check... */
 		rCorrect = rCorrect > 0.0f ? rCorrect : 0.0f;
 		gCorrect = gCorrect > 0.0f ? gCorrect : 0.0f;


### PR DESCRIPTION
This PR updates the GBA/GBC colour correction parameters based upon Pokefan531's latest research: https://forums.libretro.com/t/real-gba-and-ds-phat-colors/1540/190

GBA colours are significantly changed with this PR - the screen is somewhat darker overall, but the colours are more pleasing/rich, and far closer to those on my launch-day, non-backlit GBA (Pokefan531 has done a fantastic job, as usual!).

Here are some before/after sample screenshots:

| Before | After |
|:--------:|:-------:|
| ![Advance Wars (Europe) (En,Fr,De,Es)-200811-171216](https://user-images.githubusercontent.com/38211560/90010586-fb268700-dc97-11ea-8cff-73f8c5795396.png)  | ![Advance Wars (Europe) (En,Fr,De,Es)-200811-173435](https://user-images.githubusercontent.com/38211560/90010594-fd88e100-dc97-11ea-86ff-6020c4486241.png)  |
|  ![Legend of Zelda, The - The Minish Cap (Europe) (En,Fr,De,Es,It)-200811-174445](https://user-images.githubusercontent.com/38211560/90010607-05e11c00-dc98-11ea-9309-0b659ee86684.png) | ![Legend of Zelda, The - The Minish Cap (Europe) (En,Fr,De,Es,It)-200811-174501](https://user-images.githubusercontent.com/38211560/90010632-11344780-dc98-11ea-9766-77f255e7b69b.png)  |
| ![Mario   Luigi - Superstar Saga (Europe) (En,Fr,De,Es,It)-200811-173619](https://user-images.githubusercontent.com/38211560/90010645-17c2bf00-dc98-11ea-82c1-207527990168.png)  |  ![Mario   Luigi - Superstar Saga (Europe) (En,Fr,De,Es,It)-200811-173639](https://user-images.githubusercontent.com/38211560/90010651-198c8280-dc98-11ea-89dd-a3262f393fff.png) |
| ![Wario Land 4 (USA, Europe)-200811-171343](https://user-images.githubusercontent.com/38211560/90010672-24dfae00-dc98-11ea-8414-56199f4692ce.png)  | ![Wario Land 4 (USA, Europe)-200811-173456](https://user-images.githubusercontent.com/38211560/90010673-26a97180-dc98-11ea-8165-5c947c9f7251.png)  |

The GBC changes are more subtle - examples can be seen here: https://github.com/libretro/gambatte-libretro/pull/155
(the mGBA and Gambatte cores have essentially identical GBC colour correction)





