### PR TITLE
Interframe Blending: Increase accurracy of 'Simple/Smart (Fast)' options and remove 'Simple/Smart (Accurate)' options

### DIFF
--- a/src/platform/libretro/libretro.c
+++ b/src/platform/libretro/libretro.c
@@ -330,9 +330,7 @@ enum frame_blend_method
 {
    FRAME_BLEND_NONE = 0,
    FRAME_BLEND_MIX,
-   FRAME_BLEND_MIX_FAST,
    FRAME_BLEND_MIX_SMART,
-   FRAME_BLEND_MIX_SMART_FAST,
    FRAME_BLEND_LCD_GHOSTING,
    FRAME_BLEND_LCD_GHOSTING_FAST
 };
@@ -356,7 +354,7 @@ static bool _allocateOutputBufferPrev(color_t** buf) {
 			return false;
 		}
 	}
-	memset(*buf, 0xFF, VIDEO_BUFF_SIZE);
+	memset(*buf, 0xFFFF, VIDEO_BUFF_SIZE);
 	return true;
 }
 
@@ -404,14 +402,12 @@ static void _initFrameBlend(void) {
 	 * the next frame */
 	switch (frameBlendType) {
 		case FRAME_BLEND_MIX:
-		case FRAME_BLEND_MIX_FAST:
 			/* Simple 50:50 blending requires a single buffer */
 			if (!_allocateOutputBufferPrev(&outputBufferPrev1)) {
 				return;
 			}
 			break;
 		case FRAME_BLEND_MIX_SMART:
-		case FRAME_BLEND_MIX_SMART_FAST:
 			/* Smart 50:50 blending requires three buffers */
 			if (!_allocateOutputBufferPrev(&outputBufferPrev1)) {
 				return;
@@ -492,12 +488,8 @@ static void _loadFrameBlendSettings(void) {
 	if (environCallback(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) {
 		if (strcmp(var.value, "mix") == 0) {
 			frameBlendType = FRAME_BLEND_MIX;
-		} else if (strcmp(var.value, "mix_fast") == 0) {
-			frameBlendType = FRAME_BLEND_MIX_FAST;
 		} else if (strcmp(var.value, "mix_smart") == 0) {
 			frameBlendType = FRAME_BLEND_MIX_SMART;
-		} else if (strcmp(var.value, "mix_smart_fast") == 0) {
-			frameBlendType = FRAME_BLEND_MIX_SMART_FAST;
 		} else if (strcmp(var.value, "lcd_ghosting") == 0) {
 			frameBlendType = FRAME_BLEND_LCD_GHOSTING;
 		} else if (strcmp(var.value, "lcd_ghosting_fast") == 0) {
@@ -554,59 +546,24 @@ static void videoPostProcessMix(unsigned width, unsigned height) {
 			/* Store colours for next frame */
 			*(srcPrev + x) = rgbCurr;
 
-			/* Unpack colours and convert to float */
-			float rCurr = (float)(rgbCurr >> 11 & 0x1F);
-			float gCurr = (float)(rgbCurr >>  6 & 0x1F);
-			float bCurr = (float)(rgbCurr       & 0x1F);
+			/* Unpack colours */
+			color_t rCurr = rgbCurr >> 11 & 0x1F;
+			color_t gCurr = rgbCurr >>  6 & 0x1F;
+			color_t bCurr = rgbCurr       & 0x1F;
 
-			float rPrev = (float)(rgbPrev >> 11 & 0x1F);
-			float gPrev = (float)(rgbPrev >>  6 & 0x1F);
-			float bPrev = (float)(rgbPrev       & 0x1F);
+			color_t rPrev = rgbPrev >> 11 & 0x1F;
+			color_t gPrev = rgbPrev >>  6 & 0x1F;
+			color_t bPrev = rgbPrev       & 0x1F;
 
-			/* Mix colours for current frame and convert back to color_t */
-			color_t rMix = (color_t)(((rCurr * 0.5f) + (rPrev * 0.5f)) + 0.5f) & 0x1F;
-			color_t gMix = (color_t)(((gCurr * 0.5f) + (gPrev * 0.5f)) + 0.5f) & 0x1F;
-			color_t bMix = (color_t)(((bCurr * 0.5f) + (bPrev * 0.5f)) + 0.5f) & 0x1F;
+			/* Mix colours */
+			color_t rMix  = (rCurr >> 1) + (rPrev >> 1) + (((rCurr & 0x1) + (rPrev & 0x1)) >> 1);
+			color_t gMix  = (gCurr >> 1) + (gPrev >> 1) + (((gCurr & 0x1) + (gPrev & 0x1)) >> 1);
+			color_t bMix  = (bCurr >> 1) + (bPrev >> 1) + (((bCurr & 0x1) + (bPrev & 0x1)) >> 1);
 
 			/* Repack colours for current frame */
 			*(dst + x) = colorCorrectionEnabled ?
 					*(ccLUT + (rMix << 11 | gMix << 6 | bMix)) :
 							rMix << 11 | gMix << 6 | bMix;
-		}
-		srcCurr += VIDEO_WIDTH_MAX;
-		srcPrev += VIDEO_WIDTH_MAX;
-		dst     += VIDEO_WIDTH_MAX;
-	}
-}
-
-static void videoPostProcessMixFast(unsigned width, unsigned height) {
-
-	color_t *srcCurr = outputBuffer;
-	color_t *srcPrev = outputBufferPrev1;
-	color_t *dst     = ppOutputBuffer;
-	size_t x, y;
-
-	for (y = 0; y < height; y++) {
-		for (x = 0; x < width; x++) {
-
-			/* Get colours from current + previous frames */
-			color_t rgbCurr = *(srcCurr + x);
-			color_t rgbPrev = *(srcPrev + x);
-
-			/* Store colours for next frame */
-			*(srcPrev + x) = rgbCurr;
-
-			/* Mix colours for current frame
-			 * > Fast one-shot method (bit twiddling)
-			 * > Causes mild darkening of colours due to
-			 *   rounding errors */
-			color_t rgbMix =   ((((rgbCurr >> 11) & 0x1F) >> 1) + (((rgbPrev >> 11) & 0x1F) >> 1)) << 11
-								  | ((((rgbCurr >>  6) & 0x1F) >> 1) + (((rgbPrev >>  6) & 0x1F) >> 1)) << 6
-								  | ((( rgbCurr        & 0x1F) >> 1) + (( rgbPrev        & 0x1F) >> 1));
-
-			/* Assign colours for current frame */
-			*(dst + x) = colorCorrectionEnabled ?
-					*(ccLUT + rgbMix) : rgbMix;
 		}
 		srcCurr += VIDEO_WIDTH_MAX;
 		srcPrev += VIDEO_WIDTH_MAX;
@@ -645,81 +602,24 @@ static void videoPostProcessMixSmart(unsigned width, unsigned height) {
 			    (rgbCurr != rgbPrev3) &&
 			    (rgbPrev1 != rgbPrev2)) {
 
-				/* Unpack colours and convert to float */
-				float rCurr = (float)(rgbCurr >> 11 & 0x1F);
-				float gCurr = (float)(rgbCurr >>  6 & 0x1F);
-				float bCurr = (float)(rgbCurr       & 0x1F);
+				/* Unpack colours */
+				color_t rCurr  = rgbCurr >> 11 & 0x1F;
+				color_t gCurr  = rgbCurr >>  6 & 0x1F;
+				color_t bCurr  = rgbCurr       & 0x1F;
 
-				float rPrev1 = (float)(rgbPrev1 >> 11 & 0x1F);
-				float gPrev1 = (float)(rgbPrev1 >>  6 & 0x1F);
-				float bPrev1 = (float)(rgbPrev1       & 0x1F);
+				color_t rPrev1 = rgbPrev1 >> 11 & 0x1F;
+				color_t gPrev1 = rgbPrev1 >>  6 & 0x1F;
+				color_t bPrev1 = rgbPrev1       & 0x1F;
 
-				/* Mix colours for current frame and convert back to color_t */
-				color_t rMix = (color_t)(((rCurr * 0.5f) + (rPrev1 * 0.5f)) + 0.5f) & 0x1F;
-				color_t gMix = (color_t)(((gCurr * 0.5f) + (gPrev1 * 0.5f)) + 0.5f) & 0x1F;
-				color_t bMix = (color_t)(((bCurr * 0.5f) + (bPrev1 * 0.5f)) + 0.5f) & 0x1F;
+				/* Mix colours */
+				color_t rMix   = (rCurr >> 1) + (rPrev1 >> 1) + (((rCurr & 0x1) + (rPrev1 & 0x1)) >> 1);
+				color_t gMix   = (gCurr >> 1) + (gPrev1 >> 1) + (((gCurr & 0x1) + (gPrev1 & 0x1)) >> 1);
+				color_t bMix   = (bCurr >> 1) + (bPrev1 >> 1) + (((bCurr & 0x1) + (bPrev1 & 0x1)) >> 1);
 
 				/* Repack colours for current frame */
 				*(dst + x) = colorCorrectionEnabled ?
 						*(ccLUT + (rMix << 11 | gMix << 6 | bMix)) :
 								rMix << 11 | gMix << 6 | bMix;
-
-			} else {
-				/* Just use colours for current frame */
-				*(dst + x) = colorCorrectionEnabled ?
-						*(ccLUT + rgbCurr) :	rgbCurr;
-			}
-		}
-		srcCurr  += VIDEO_WIDTH_MAX;
-		srcPrev1 += VIDEO_WIDTH_MAX;
-		srcPrev2 += VIDEO_WIDTH_MAX;
-		srcPrev3 += VIDEO_WIDTH_MAX;
-		dst      += VIDEO_WIDTH_MAX;
-	}
-}
-
-static void videoPostProcessMixSmartFast(unsigned width, unsigned height) {
-
-	color_t *srcCurr  = outputBuffer;
-	color_t *srcPrev1 = outputBufferPrev1;
-	color_t *srcPrev2 = outputBufferPrev2;
-	color_t *srcPrev3 = outputBufferPrev3;
-	color_t *dst      = ppOutputBuffer;
-	size_t x, y;
-
-	for (y = 0; y < height; y++) {
-		for (x = 0; x < width; x++) {
-
-			/* Get colours from current + previous frames */
-			color_t rgbCurr  = *(srcCurr + x);
-			color_t rgbPrev1 = *(srcPrev1 + x);
-			color_t rgbPrev2 = *(srcPrev2 + x);
-			color_t rgbPrev3 = *(srcPrev3 + x);
-
-			/* Store colours for next frame */
-			*(srcPrev1 + x) = rgbCurr;
-			*(srcPrev2 + x) = rgbPrev1;
-			*(srcPrev3 + x) = rgbPrev2;
-
-			/* Determine whether mixing is required
-			 * i.e. whether alternate frames have the same pixel colour,
-			 * but adjacent frames do not */
-			if (((rgbCurr == rgbPrev2) || (rgbPrev1 == rgbPrev3)) &&
-				 (rgbCurr != rgbPrev1) &&
-			    (rgbCurr != rgbPrev3) &&
-			    (rgbPrev1 != rgbPrev2)) {
-
-				/* Mix colours for current frame
-				 * > Fast one-shot method (bit twiddling)
-				 * > Causes mild darkening of colours due to
-				 *   rounding errors */
-				color_t rgbMix =   ((((rgbCurr >> 11) & 0x1F) >> 1) + (((rgbPrev1 >> 11) & 0x1F) >> 1)) << 11
-									  | ((((rgbCurr >>  6) & 0x1F) >> 1) + (((rgbPrev1 >>  6) & 0x1F) >> 1)) << 6
-									  | ((( rgbCurr        & 0x1F) >> 1) + (( rgbPrev1        & 0x1F) >> 1));
-
-				/* Assign colours for current frame */
-				*(dst + x) = colorCorrectionEnabled ?
-						*(ccLUT + rgbMix) : rgbMix;
 
 			} else {
 				/* Just use colours for current frame */
@@ -889,7 +789,7 @@ static void _initPostProcessing(void) {
 		if (!ppOutputBuffer) {
 			return;
 		}
-		memset(ppOutputBuffer, 0xFF, VIDEO_BUFF_SIZE);
+		memset(ppOutputBuffer, 0xFFFF, VIDEO_BUFF_SIZE);
 	}
 
 	/* Assign post processing function */
@@ -898,14 +798,8 @@ static void _initPostProcessing(void) {
 			case FRAME_BLEND_MIX:
 				videoPostProcess = videoPostProcessMix;
 				return;
-			case FRAME_BLEND_MIX_FAST:
-				videoPostProcess = videoPostProcessMixFast;
-				return;
 			case FRAME_BLEND_MIX_SMART:
 				videoPostProcess = videoPostProcessMixSmart;
-				return;
-			case FRAME_BLEND_MIX_SMART_FAST:
-				videoPostProcess = videoPostProcessMixSmartFast;
 				return;
 			case FRAME_BLEND_LCD_GHOSTING:
 				videoPostProcess = videoPostProcessLcdGhost;
@@ -1696,7 +1590,7 @@ bool retro_load_game(const struct retro_game_info* game) {
 #else
 	outputBuffer = malloc(VIDEO_BUFF_SIZE);
 #endif
-	memset(outputBuffer, 0xFF, VIDEO_BUFF_SIZE);
+	memset(outputBuffer, 0xFFFF, VIDEO_BUFF_SIZE);
 	core->setVideoBuffer(core, outputBuffer, VIDEO_WIDTH_MAX);
 
 	core->setAudioBufferSize(core, SAMPLES);

--- a/src/platform/libretro/libretro_core_options.h
+++ b/src/platform/libretro/libretro_core_options.h
@@ -180,10 +180,8 @@ struct retro_core_option_definition option_defs_us[] = {
       "Simulates LCD ghosting effects. 'Simple' performs a 50:50 mix of the current and previous frames. 'Smart' attempts to detect screen flickering, and only performs a 50:50 mix on affected pixels. 'LCD Ghosting' mimics natural LCD response times by combining multiple buffered frames. 'Simple' or 'Smart' blending is required when playing games that aggressively exploit LCD ghosting for transparency effects (Wave Race, Chikyuu Kaihou Gun ZAS, F-Zero, the Boktai series...).",
       {
          { "OFF",               NULL },
-         { "mix",               "Simple (Accurate)" },
-         { "mix_fast",          "Simple (Fast)" },
-         { "mix_smart",         "Smart (Accurate)" },
-         { "mix_smart_fast",    "Smart (Fast)" },
+         { "mix",               "Simple" },
+         { "mix_smart",         "Smart" },
          { "lcd_ghosting",      "LCD Ghosting (Accurate)" },
          { "lcd_ghosting_fast", "LCD Ghosting (Fast)" },
          { NULL, NULL },


### PR DESCRIPTION
This PR improves the accuracy of the `Simple (Fast)` and `Smart (Fast)` interframe blending options such that they produce the same results as the `(Accurate)` methods. The `Simple (Accurate)` and `Smart (Accurate)` options have therefore been removed, and the 'fast' options renamed to just `Simple`/`Smart`