### PR TITLE
Add GBP rumble option

### DIFF
--- a/src/gba/core.c
+++ b/src/gba/core.c
@@ -287,6 +287,7 @@ static void _GBACoreLoadConfig(struct mCore* core, const struct mCoreConfig* con
 
 	mCoreConfigCopyValue(&core->config, config, "allowOpposingDirections");
 	mCoreConfigCopyValue(&core->config, config, "gba.bios");
+	mCoreConfigCopyValue(&core->config, config, "gba.forceGbp");
 	mCoreConfigCopyValue(&core->config, config, "gba.audioHle");
 
 #ifndef DISABLE_THREADING
@@ -517,6 +518,7 @@ static void _GBACoreChecksum(const struct mCore* core, void* data, enum mCoreChe
 static void _GBACoreReset(struct mCore* core) {
 	struct GBACore* gbacore = (struct GBACore*) core;
 	struct GBA* gba = (struct GBA*) core->board;
+	int fakeBool;
 	if (gbacore->renderer.outputBuffer
 #if defined(BUILD_GLES2) || defined(BUILD_GLES3)
 	    || gbacore->glRenderer.outputTex != (unsigned) -1
@@ -526,7 +528,6 @@ static void _GBACoreReset(struct mCore* core) {
 		if (gbacore->renderer.outputBuffer) {
 			renderer = &gbacore->renderer.d;
 		}
-		int fakeBool ATTRIBUTE_UNUSED;
 #if defined(BUILD_GLES2) || defined(BUILD_GLES3)
 		if (gbacore->glRenderer.outputTex != (unsigned) -1 && mCoreConfigGetIntValue(&core->config, "hwaccelVideo", &fakeBool) && fakeBool) {
 			renderer = &gbacore->glRenderer.d;
@@ -562,7 +563,17 @@ static void _GBACoreReset(struct mCore* core) {
 	}
 #endif
 
+	bool forceGbp = false;
+	if (mCoreConfigGetIntValue(&core->config, "gba.forceGbp", &fakeBool)) {
+		forceGbp = fakeBool;
+	}
+	if (!forceGbp) {
+		gba->memory.hw.devices &= ~HW_GB_PLAYER_DETECTION;
+	}
 	GBAOverrideApplyDefaults(gba, gbacore->overrides);
+	if (forceGbp) {
+		gba->memory.hw.devices |= HW_GB_PLAYER_DETECTION;
+	}
 
 #if !defined(MINIMAL_CORE) || MINIMAL_CORE < 2
 	if (!gba->biosVf && core->opts.useBios) {

--- a/src/platform/libretro/libretro.c
+++ b/src/platform/libretro/libretro.c
@@ -988,6 +988,14 @@ static void _reloadSettings(void) {
 		}
 	}
 
+#ifdef M_CORE_GBA
+	var.key = "mgba_force_gbp";
+	var.value = 0;
+	if (environCallback(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) {
+		mCoreConfigSetDefaultIntValue(&core->config, "gba.forceGbp", strcmp(var.value, "ON") == 0);
+	}
+#endif
+
 	mCoreConfigLoadDefaults(&core->config, &opts);
 	mCoreLoadConfig(core);
 }

--- a/src/platform/libretro/libretro_core_options.h
+++ b/src/platform/libretro/libretro_core_options.h
@@ -189,6 +189,17 @@ struct retro_core_option_definition option_defs_us[] = {
       "OFF"
    },
 #endif
+   {
+      "mgba_force_gbp",
+      "Enable Game Boy Player Rumble (requires restart)",
+      "Enabling this will allow compatible games with the Game Boy Player boot logo to make the controller rumble. Due to how Nintendo decided this feature should work, it may cause glitches such as flickering or lag in some of these games.",
+      {
+         { "OFF", NULL },
+         { "ON",  NULL },
+         { NULL, NULL },
+      },
+      "OFF"
+   },
    { NULL, NULL, NULL, {{0}}, NULL },
 };
 


### PR DESCRIPTION
As described in #200. There ended up being a change I needed to make on the emulator side that I wasn't expecting, but not a big one. Replaces #200, fixes #192. It does _not_ fix #158, but it does enable the thing the user in that issue was trying to accomplish with that request.