### PR TITLE
Android: Reduce target API level to 16 (Android 4.1+)

### DIFF
--- a/libretro-build/jni/Application.mk
+++ b/libretro-build/jni/Application.mk
@@ -1,3 +1,3 @@
 APP_ABI := all
-APP_PLATFORM := android-19
+APP_PLATFORM := android-16
 APP_STL := c++_static


### PR DESCRIPTION
This PR just sets the Android API level to 16, enabling compatibility with Android 4.1+.

This should address #224