### PR TITLE
Libretro: Lazy-load rumble interface

### DIFF
--- a/src/platform/libretro/libretro.c
+++ b/src/platform/libretro/libretro.c
@@ -83,6 +83,7 @@ static size_t dataSize;
 static void* savedata;
 static struct mAVStream stream;
 static bool sensorsInitDone;
+static bool rumbleInitDone;
 static int rumbleUp;
 static int rumbleDown;
 static struct mRumble rumble;
@@ -1030,6 +1031,19 @@ static void _initSensors(void) {
 	sensorsInitDone = true;
 }
 
+static void _initRumble(void) {
+	if (rumbleInitDone) {
+		return;
+	}
+
+	struct retro_rumble_interface rumbleInterface;
+	if (environCallback(RETRO_ENVIRONMENT_GET_RUMBLE_INTERFACE, &rumbleInterface)) {
+		rumbleCallback = rumbleInterface.set_rumble_state;
+	}
+
+	rumbleInitDone = true;
+}
+
 static void _reloadSettings(void) {
 	struct mCoreOptions opts = {
 		.useBios = true,
@@ -1224,13 +1238,9 @@ void retro_init(void) {
 
 	// TODO: RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME when BIOS booting is supported
 
-	struct retro_rumble_interface rumbleInterface;
-	if (environCallback(RETRO_ENVIRONMENT_GET_RUMBLE_INTERFACE, &rumbleInterface)) {
-		rumbleCallback = rumbleInterface.set_rumble_state;
-		rumble.setRumble = _setRumble;
-	} else {
-		rumbleCallback = 0;
-	}
+	rumbleInitDone = false;
+	rumble.setRumble = _setRumble;
+	rumbleCallback = 0;
 
 	sensorsInitDone = false;
 	sensorGetCallback = 0;
@@ -2110,6 +2120,9 @@ static void _postAudioBuffer(struct mAVStream* stream, blip_t* left, blip_t* rig
 
 static void _setRumble(struct mRumble* rumble, int enable) {
 	UNUSED(rumble);
+	if (!rumbleInitDone) {
+		_initRumble();
+	}
 	if (!rumbleCallback) {
 		return;
 	}


### PR DESCRIPTION
At present, on platforms with rumble support, the core calls `rumbleCallback()` twice each frame - regardless of whether the current content uses rumble functionality.

Inspired by #225, this PR defers the 'loading' of the rumble interface until the first time that rumble is used. This means `rumbleCallback()` is only called when running rumble-enabled games.

cc @endrift 