### PR TITLE
Add compile flags for Odroid Go Advance

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -117,6 +117,19 @@ else ifeq ($(platform), rpi4_64)
    DEFINES += -std=c99 -D_GNU_SOURCE -DHAVE_LOCALE
    HAVE_VFS_FD = 0
 
+# Go-Advance 
+else ifeq ($(platform), goadvance)
+   CPUFLAGS := -Ofast -march=armv8-a+crc+fp+simd -mcpu=cortex-a35 -flto -DUSE_RENDER_THREAD -DNO_ASM -DARM_ASM -frename-registers -ftree-vectorize
+   CFLAGS   := -DNDEBUG -Ofast -fno-ident
+   LDFLAGS  += -Ofast -fno-ident
+   CFLAGS  += $(CPUFLAGS) -fpic -fomit-frame-pointer -fno-exceptions -fno-non-call-exceptions -Wno-psabi -Wno-format
+   LDFLAGS += $(CPUFLAGS) -lpthread -Wl,--gc-sections -shared
+   TARGET := $(TARGET_NAME)_libretro.so
+   fpic := -fPIC
+   SHARED := -shared -Wl,-version-script=link.T
+   DEFINES += -std=c99 -D_GNU_SOURCE -DHAVE_LOCALE
+   HAVE_VFS_FD = 0
+
 # (armv7 a7, hard point, neon based) ### 
 # NESC, SNESC, C64 mini 
 else ifeq ($(platform), classic_armv7_a7)


### PR DESCRIPTION
Provides best optimized performance for the Odroid Go Advance and related clones that use the same RK3326 chipset