### PR TITLE
Expose and update emulator version

### DIFF
--- a/src/platform/libretro/libretro.c
+++ b/src/platform/libretro/libretro.c
@@ -1259,7 +1259,7 @@ void retro_get_system_info(struct retro_system_info* info) {
 #ifndef GIT_VERSION
 #define GIT_VERSION ""
 #endif
-	info->library_version = GIT_VERSION;
+	info->library_version = "0.9.2" GIT_VERSION;
 	info->library_name = "mGBA";
 	info->block_extract = false;
 }


### PR DESCRIPTION
Just a quick update to `libretro.c` to expose the emulator version (currently 0.9.2) before the commit hash, as was the case for the previous versions of the same core.