### PR TITLE
Update emulator version string in libretro.c

### DIFF
--- a/src/platform/libretro/libretro.c
+++ b/src/platform/libretro/libretro.c
@@ -1329,7 +1329,7 @@ void retro_get_system_info(struct retro_system_info* info) {
 #ifndef GIT_VERSION
 #define GIT_VERSION ""
 #endif
-	info->library_version = "0.9.2" GIT_VERSION;
+	info->library_version = "0.9.3" GIT_VERSION;
 	info->library_name = "mGBA";
 	info->block_extract = false;
 }


### PR DESCRIPTION
As per my proposal in https://github.com/libretro/mgba/pull/240, this is a simple manual edit of the `library_version` string, reflecting the latest emulator update (0.9.2 -> 0.9.3).