### PR TITLE
Let GCC chose the proper march and mcpu flags for each Pi model

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -47,10 +47,12 @@ ifeq ($(platform),)
       platform = win
    else ifneq ($(findstring Darwin,$(shell uname -s)),)
       platform = osx
+      arch = intel
+      ifeq ($(shell uname -p),arm64)
+         arch = arm
+      endif
       ifeq ($(shell uname -p),powerpc)
          arch = ppc
-      else
-         arch = intel
       endif
    else ifneq ($(findstring win,$(shell uname -s)),)
       platform = win
@@ -59,7 +61,7 @@ else ifneq (,$(findstring armv,$(platform)))
 	ifeq (,$(findstring classic_,$(platform)))
 		override platform += unix
 	endif
-else ifneq (,$(findstring rpi3,$(platform)))
+else ifneq (,$(findstring rpi,$(platform)))
 	override platform += unix
 endif
 
@@ -94,24 +96,23 @@ ifneq (,$(findstring unix,$(platform)))
    else
       DEFINES += -std=c99 -D_GNU_SOURCE -DHAVE_LOCALE
    endif
+endif
 
-# Raspberry Pi 3
-else ifeq ($(platform), rpi3)
-   TARGET := $(TARGET_NAME)_libretro.so
-   fpic := -fPIC
-   SHARED := -shared -Wl,-version-script=link.T
-   CFLAGS += -marm -mcpu=cortex-a53 -mfloat-abi=hard
-   CFLAGS += -fomit-frame-pointer
-   DEFINES += -std=c99 -D_GNU_SOURCE -DHAVE_LOCALE
+# Raspberry Pi: GCC provides the right cflags for each model.
+ifneq ($(platform), rpi)
+   CFLAGS += -march=native -mcpu=native -ftree-vectorize -pipe -fomit-frame-pointer
    HAVE_VFS_FD = 0
 
-# Raspberry Pi 4 in 64bit mode
-else ifeq ($(platform), rpi4_64)
+# Go-Advance 
+else ifeq ($(platform), goadvance)
+   CPUFLAGS := -Ofast -march=armv8-a+crc+fp+simd -mcpu=cortex-a35 -flto -DUSE_RENDER_THREAD -DNO_ASM -DARM_ASM -frename-registers -ftree-vectorize
+   CFLAGS   := -DNDEBUG -Ofast -fno-ident
+   LDFLAGS  += -Ofast -fno-ident
+   CFLAGS  += $(CPUFLAGS) -fpic -fomit-frame-pointer -fno-exceptions -fno-non-call-exceptions -Wno-psabi -Wno-format
+   LDFLAGS += $(CPUFLAGS) -lpthread -Wl,--gc-sections -shared
    TARGET := $(TARGET_NAME)_libretro.so
    fpic := -fPIC
    SHARED := -shared -Wl,-version-script=link.T
-   CFLAGS += -march=armv8-a+crc+simd -mtune=cortex-a72
-   CFLAGS += -fomit-frame-pointer
    DEFINES += -std=c99 -D_GNU_SOURCE -DHAVE_LOCALE
    HAVE_VFS_FD = 0
 
@@ -182,7 +183,9 @@ else ifeq ($(platform), osx)
    SHARED := -dynamiclib
    OSXVER = `sw_vers -productVersion | cut -d. -f 2`
    OSX_LT_MAVERICKS = `(( $(OSXVER) <= 9)) && echo "YES"`
-   fpic += -mmacosx-version-min=10.1
+   ifeq ($(OSX_LT_MAVERICKS),YES)
+   	   fpic += -mmacosx-version-min=10.1
+   endif
    ifndef ($(NOUNIVERSAL))
       CFLAGS += $(ARCHFLAGS)
       LDFLAGS += $(ARCHFLAGS)
@@ -191,6 +194,12 @@ else ifeq ($(platform), osx)
       DEFINES += -D__POWERPC__ -D__PPC__ -DMSB_FIRST
    endif
    DEFINES += -std=gnu99
+	DEFINES += -DHAVE_STRLCPY
+   ifeq ($(CROSS_COMPILE),1)
+	TARGET_RULE  = -target $(LIBRETRO_APPLE_PLATFORM) -isysroot $(LIBRETRO_APPLE_ISYSROOT)
+	CFLAGS      += $(TARGET_RULE)
+	LDFLAGS     += $(TARGET_RULE)
+   endif
 
 # iOS
 else ifneq (,$(findstring ios,$(platform)))
@@ -213,6 +222,7 @@ else ifneq (,$(findstring ios,$(platform)))
       PLATFORM_DEFINES := -miphoneos-version-min=5.0
    endif
    DEFINES += -std=c99
+   DEFINES += -DHAVE_STRLCPY
 
 # tvOS
 else ifeq ($(platform), tvos-arm64)
@@ -221,6 +231,7 @@ else ifeq ($(platform), tvos-arm64)
    SHARED := -dynamiclib
    CFLAGS := -DIOS
    DEFINES += -std=c99
+   DEFINES += -DHAVE_STRLCPY
 
 ifeq ($(IOSSDK),)
    IOSSDK := $(shell xcodebuild -version -sdk appletvos Path)
@@ -248,37 +259,22 @@ else ifeq ($(platform), qnx)
    DEFINES += -Wc,-std=c99
 
 # PS3
-else ifneq (,$(filter $(platform), ps3 sncps3 psl1ght))
-   TARGET := $(TARGET_NAME)_libretro_ps3.a
-   PLATFORM_DEFINES := -D__CELLOS_LV2__
+else ifneq (,$(filter $(platform), psl1ght))
+   TARGET := $(TARGET_NAME)_libretro_$(platform).a
+   CC = $(PS3DEV)/ppu/bin/ppu-gcc$(EXE_EXT)
+   AR = $(PS3DEV)/ppu/bin/ppu-ar$(EXE_EXT)
+   PLATFORM_DEFINES := -D__PPC__ -D__BIG_ENDIAN__
    STATIC_LINKING = 1
    DEFINES += -std=gnu99 -fms-extensions
    HAVE_VFS_FD = 0
 
-   # sncps3
-   ifneq (,$(findstring sncps3,$(platform)))
-      CC = $(CELL_SDK)/host-win32/sn/bin/ps3ppusnc.exe
-      AR = $(CELL_SDK)/host-win32/sn/bin/ps3snarl.exe
-
-   # PS3
-   else ifneq (,$(findstring ps3,$(platform)))
-      CC = $(CELL_SDK)/host-win32/ppu/bin/ppu-lv2-gcc.exe
-      AR = $(CELL_SDK)/host-win32/ppu/bin/ppu-lv2-ar.exe
-
-   # Lightweight PS3 Homebrew SDK
-   else ifneq (,$(findstring psl1ght,$(platform)))
-      TARGET := $(TARGET_NAME)_libretro_$(platform).a
-      CC = $(PS3DEV)/ppu/bin/ppu-gcc$(EXE_EXT)
-      AR = $(PS3DEV)/ppu/bin/ppu-ar$(EXE_EXT)
-   endif
-
 # PS2
 else ifeq ($(platform), ps2)
    TARGET := $(TARGET_NAME)_libretro_$(platform).a
-   CC = ee-gcc$(EXE_EXT)
-   AR = ee-ar$(EXE_EXT)
+   CC = mips64r5900el-ps2-elf-gcc$(EXE_EXT)
+   AR = mips64r5900el-ps2-elf-ar$(EXE_EXT)
    PLATFORM_DEFINES := -DPS2 -DCC_RESAMPLER
-   CFLAGS += -G0 -DHAVE_NO_LANGEXTRA
+   CFLAGS += -G0 -DHAVE_NO_LANGEXTRA -DHAVE_STRTOF_L
    STATIC_LINKING = 1
    DEFINES += -std=c99
 	HAVE_VFS_FD = 0
@@ -299,7 +295,7 @@ else ifeq ($(platform), vita)
    TARGET := $(TARGET_NAME)_libretro_$(platform).a
    CC = arm-vita-eabi-gcc$(EXE_EXT)
    AR = arm-vita-eabi-ar$(EXE_EXT)
-   PLATFORM_DEFINES := -DVITA -DCC_RESAMPLER -DPSP2
+   PLATFORM_DEFINES := -DVITA -DCC_RESAMPLER -DPSP2 -DHAVE_STRTOF_L
    STATIC_LINKING = 1
    DEFINES += -std=c99
 
@@ -393,7 +389,8 @@ else ifeq ($(platform), genode)
 # emscripten
 else ifeq ($(platform), emscripten)
    TARGET := $(TARGET_NAME)_libretro_$(platform).bc
-   DEFINES += -std=gnu99 -DHAVE_LOCALE
+   DEFINES += -std=gnu99 -DHAVE_LOCALE -D_GNU_SOURCE -DHAVE_STRTOF_L
+   STATIC_LINKING = 1
 
 # GCW0
 else ifeq ($(platform), gcw0)
@@ -404,6 +401,18 @@ else ifeq ($(platform), gcw0)
    AR = /opt/gcw0-toolchain/usr/bin/mipsel-linux-ar
    PLATFORM_DEFINES += -D_GNU_SOURCE
    CFLAGS += -fomit-frame-pointer -ffast-math -march=mips32 -mtune=mips32r2 -mhard-float
+   CFLAGS += -fno-common -ftree-vectorize -funswitch-loops
+   DEFINES += -std=c99
+
+# MIYOO
+else ifeq ($(platform), miyoo)
+   TARGET := $(TARGET_NAME)_libretro.so
+   fpic := -fPIC
+   SHARED := -shared -Wl,-version-script=link.T
+   CC = /opt/miyoo/usr/bin/arm-linux-gcc
+   AR = /opt/miyoo/usr/bin/arm-linux-ar
+   PLATFORM_DEFINES += -D_GNU_SOURCE
+   CFLAGS += -fomit-frame-pointer -ffast-math -march=armv5te -mtune=arm926ej-s
    CFLAGS += -fno-common -ftree-vectorize -funswitch-loops
    DEFINES += -std=c99
 
@@ -418,13 +427,11 @@ endif
 
 ifeq ($(DEBUG), 1)
    CFLAGS += -O0 -g
-else ifeq ($(platform), emscripten)
-   CFLAGS += -O2
 else
    CFLAGS += -O3
 endif
 
-DEFINES += -DHAVE_STRNDUP -DHAVE_STRDUP -DDISABLE_THREADING
+DEFINES += -DHAVE_STRNDUP -DHAVE_STRDUP -DDISABLE_THREADING -DMINIMAL_CORE=2
 
 include $(BUILD_DIR)/Makefile.common
 


### PR DESCRIPTION
Modern GCC provides the right flags for each Pi model, so we don't need a chunk of ifeqs for that. 
Also, fixed the rpi platform in general since there was a typo on the platform redefinition as unix.