### PR TITLE
Fix Pi platform recognition again.

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -61,8 +61,6 @@ else ifneq (,$(findstring armv,$(platform)))
 	ifeq (,$(findstring classic_,$(platform)))
 		override platform += unix
 	endif
-else ifneq (,$(findstring rpi,$(platform)))
-	override platform += unix
 endif
 
 prefix := /usr


### PR DESCRIPTION
I had accidentally left Rpi->Plain UNIX assimilation line, so Pi flags were being ignored again. Fixed.