### PR TITLE
Change the "Starting DMA" log level to debug for Libretro

### DIFF
--- a/src/gba/dma.c
+++ b/src/gba/dma.c
@@ -96,7 +96,11 @@ uint16_t GBADMAWriteCNT_HI(struct GBA* gba, int dma, uint16_t control) {
 		if (currentDma->nextDest & (width - 1)) {
 			mLOG(GBA_DMA, GAME_ERROR, "Misaligned DMA destination address: 0x%08X", currentDma->nextDest);
 		}
+#ifndef __LIBRETRO__
 		mLOG(GBA_DMA, INFO, "Starting DMA %i 0x%08X -> 0x%08X (%04X:%04X)", dma,
+#else
+		mLOG(GBA_DMA, DEBUG, "Starting DMA %i 0x%08X -> 0x%08X (%04X:%04X)", dma,
+#endif
 		     currentDma->nextSource, currentDma->nextDest,
 		     currentDma->reg, currentDma->count & 0xFFFF);
 


### PR DESCRIPTION
It's been a month since I opened an issue about this, I guess it was forgotten :p Anyway here's a PR with the ifdef solution talked in #265. If the other method is preferred (making it debug globally) please tell me, I'll update the PR. Also tell me if I should PR upstream too.

But yeah some people are reporting huge performance drops the longer they play and even crashes after a while, so even if it looks trivial I think this is an important thing to "fix".

Fixes #265 