### PR TITLE
Tools: Allow RetroArch to search game memory for cheats

### DIFF
--- a/src/platform/libretro/libretro.c
+++ b/src/platform/libretro/libretro.c
@@ -1750,12 +1750,14 @@ static void _setupMaps(struct mCore* core) {
 		descs[0].start  = GBA_BASE_IWRAM;
 		descs[0].len    = GBA_SIZE_IWRAM;
 		descs[0].select = 0xFF000000;
+		descs[0].flags  = RETRO_MEMDESC_SYSTEM_RAM; // Allow RetroArch to access this memory for cheats
 
 		/* Map working RAM */
 		descs[1].ptr    = gba->memory.wram;
 		descs[1].start  = GBA_BASE_EWRAM;
 		descs[1].len    = GBA_SIZE_EWRAM;
 		descs[1].select = 0xFF000000;
+		descs[1].flags  = RETRO_MEMDESC_SYSTEM_RAM; // Allow RetroArch to access this memory for cheats
 
 		/* Map save RAM */
 		/* TODO: if SRAM is flash, use start=0 addrspace="S" instead */
@@ -1851,12 +1853,14 @@ static void _setupMaps(struct mCore* core) {
 		descs[i].ptr    = gb->memory.wram;
 		descs[i].start  = GB_BASE_WORKING_RAM_BANK0;
 		descs[i].len    = GB_SIZE_WORKING_RAM_BANK0;
+		descs[i].flags  = RETRO_MEMDESC_SYSTEM_RAM;  // Allow RetroArch to access this memory for cheats
 		i++;
 
 		descs[i].ptr    = gb->memory.wram;
 		descs[i].offset = GB_SIZE_WORKING_RAM_BANK0;
 		descs[i].start  = GB_BASE_WORKING_RAM_BANK1;
 		descs[i].len    = GB_SIZE_WORKING_RAM_BANK0;
+		descs[i].flags  = RETRO_MEMDESC_SYSTEM_RAM; // Allow RetroArch to access this memory for cheats
 		i++;
 
 		/* Map OAM */
@@ -1877,6 +1881,7 @@ static void _setupMaps(struct mCore* core) {
 		descs[i].start  = GB_BASE_HRAM;
 		descs[i].len    = GB_SIZE_HRAM;
 		descs[i].select = 0xFFFFFF80;
+		descs[i].flags  = RETRO_MEMDESC_SYSTEM_RAM; // Allow RetroArch to access this memory for cheats
 		i++;
 
 		/* Map IE Register */
@@ -1901,6 +1906,7 @@ static void _setupMaps(struct mCore* core) {
 			descs[i].start  = 0x10000;
 			descs[i].len    = GB_SIZE_WORKING_RAM - 0x2000;
 			descs[i].select = 0xFFFFA000;
+			descs[i].flags  = RETRO_MEMDESC_SYSTEM_RAM; // Allow RetroArch to access this memory for cheats
 			i++;
 		}
 


### PR DESCRIPTION
## Description

This pull request addresses an issue with the mGBA core in RetroArch where the cheat search functionality's searchable memory space was not correctly set. This limitation prevented users from accessing and modifying important in-game variables, such as player HP, which are stored beyond the specified range.

From the implementation of [RetroArch's `cheat_manager_initialize_memory` function](https://github.com/libretro/RetroArch/blob/b3f3856db20f0405070e3cd66ffb382d9afbff75/cheat_manager.c#L811), it can be seen that RetroArch's cheat functionality only searches memory regions that have the `RETRO_MEMDESC_SYSTEM_RAM` flag.

By setting the `RETRO_MEMDESC_SYSTEM_RAM` flag on additional memory regions, this update expands the searchable memory space. This change ensures that RetroArch's cheat functionality can access all dynamic game data.

## Changes

- Enabled `RETRO_MEMDESC_SYSTEM_RAM` flag for:
  - GBA:
    - Internal Work RAM (IWRAM)
    - External Work RAM (EWRAM)
  - GB / GBC
    - Working RAM (WRAM)
    - High RAM (HRAM)

## Related Issue

This PR resolves #299 and #293, where users reported that the cheat search was unable to locate certain in-game variables due to the restricted memory search range.

## Testing

Performed basic tests on Windows 11 24H2 x86_64. Verified with GBA and GBC games, and confirmed that RetroArch's cheat functionality now correctly searches these memory ranges.
