### PR TITLE
Split gba_gbc_bios.bin from gbc_bios.bin

### DIFF
--- a/src/gb/core.c
+++ b/src/gb/core.c
@@ -667,7 +667,7 @@ static void _GBCoreReset(struct mCore* core) {
 			case GB_MODEL_CGB:
 			case GB_MODEL_AGB:
 			case GB_MODEL_SCGB:
-				strncat(path, PATH_SEP "gbc_bios.bin", PATH_MAX - strlen(path) - 1);
+				strncat(path, PATH_SEP "gba_gbc_bios.bin", PATH_MAX - strlen(path) - 1);
 				break;
 			default:
 				break;

--- a/src/platform/libretro/libretro.c
+++ b/src/platform/libretro/libretro.c
@@ -2111,7 +2111,7 @@ bool retro_load_game(const struct retro_game_info* game) {
 		switch (gb->model) {
 		case GB_MODEL_AGB:
 		case GB_MODEL_CGB:
-			biosName = "gbc_bios.bin";
+			biosName = "gba_gbc_bios.bin";
 			break;
 		case GB_MODEL_SGB:
 			biosName = "sgb_bios.bin";


### PR DESCRIPTION
Within the past several years, two versions of the boot ROM used in the GBA's GBC mode have been dumped, with rev1 being supported in mGBA already (an issue has been opened upstream in relation to support for the rev0 GBC mode boot ROM as well as rev2/revE of the original GBC's boot ROM). As this is primarily a GBA emulator, the boot ROM used for GBC games on the GBA itself should be the default (though the other GBC BIOS revisions should remain supported). But as other GBC emulators use the rev1 GBC BIOS under gbc_bios.bin, the GBC mode BIOS should be split into a separate file, for which I propose the name "gba_gbc_bios.bin". Perhaps there should be some logic to use gbc_bios.bin if gba_gbc_bios.bin isn't available but the former is, however I am not a programmer, so my capability on this front is minimal.