### PR TITLE
Add support for 16KB pages on Android.

### DIFF
--- a/libretro-build/jni/Android.mk
+++ b/libretro-build/jni/Android.mk
@@ -18,6 +18,6 @@ LOCAL_MODULE    := retro
 LOCAL_SRC_FILES := $(SOURCES_C) $(SOURCES_CXX)
 LOCAL_CPPFLAGS  := -O3 $(COREFLAGS)
 LOCAL_CFLAGS    := -O3 $(COREFLAGS)
-LOCAL_LDFLAGS   := -Wl,-version-script=$(CORE_DIR)/link.T
+LOCAL_LDFLAGS   := -Wl,-version-script=$(CORE_DIR)/link.T,-z,max-page-size=16384
 LOCAL_ARM_MODE  := arm
 include $(BUILD_SHARED_LIBRARY)


### PR DESCRIPTION
Since last year Google is requiring every application on Google Play to support 16KB pages: https://android-developers.googleblog.com/2025/05/prepare-play-apps-for-devices-with-16kb-page-size.html

It's a tiny build script change, I've tested it locally and it's working fine.

We did a test pilot with fceumm (https://github.com/libretro/libretro-fceumm/pull/644) and now I'm creating all the PRs for the other cores.