### PR TITLE
Add OpenGL high-resolution renderer to the libretro core

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -1,5 +1,20 @@
 DEBUG = 0
 HAVE_VFS_FD := 1
+
+ifeq ($(origin HAVE_OPENGL),undefined)
+ifneq (,$(filter win windows_x86 windows_x86_64 mingw_x86 mingw_x86_64,$(platform)))
+HAVE_OPENGL := 1
+else ifeq ($(platform),)
+ifeq ($(OS),Windows_NT)
+HAVE_OPENGL := 1
+else
+HAVE_OPENGL := 0
+endif
+else
+HAVE_OPENGL := 0
+endif
+endif
+
 CORE_DIR := .
 BUILD_DIR := libretro-build
 

--- a/include/mgba/gba/core.h
+++ b/include/mgba/gba/core.h
@@ -12,6 +12,8 @@ CXX_GUARD_START
 
 struct mCore;
 struct mCore* GBACoreCreate(void);
+/* Detach the GL renderer after its context has already been lost. */
+void GBACoreInvalidateVideoGLContext(struct mCore* core);
 #ifndef MINIMAL_CORE
 struct mCore* GBAVideoLogPlayerCreate(void);
 #endif

--- a/include/mgba/internal/gba/renderers/gl-dispatch.h
+++ b/include/mgba/internal/gba/renderers/gl-dispatch.h
@@ -1,0 +1,285 @@
+/* Copyright (c) 2013-2026 mGBA contributors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+/* Minimal OpenGL 3.3 dispatch declarations for platforms that own the
+ * context and resolve entry points dynamically. */
+#ifndef MGBA_INTERNAL_GBA_RENDERERS_GL_DISPATCH_H
+#define MGBA_INTERNAL_GBA_RENDERERS_GL_DISPATCH_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef unsigned int GLenum;
+typedef unsigned char GLboolean;
+typedef unsigned int GLbitfield;
+typedef signed char GLbyte;
+typedef short GLshort;
+typedef int GLint;
+typedef int GLsizei;
+typedef unsigned char GLubyte;
+typedef unsigned short GLushort;
+typedef unsigned int GLuint;
+typedef float GLfloat;
+typedef double GLdouble;
+typedef char GLchar;
+typedef ptrdiff_t GLintptr;
+typedef ptrdiff_t GLsizeiptr;
+
+#if defined(_WIN32) && (defined(_M_IX86) || defined(__i386__))
+#if defined(_MSC_VER)
+#define M_GBA_GL_APIENTRY __stdcall
+#else
+#define M_GBA_GL_APIENTRY __attribute__((stdcall))
+#endif
+#else
+#define M_GBA_GL_APIENTRY
+#endif
+
+#define GL_FALSE                         0
+#define GL_TRUE                          1
+#define GL_NONE                          0
+#define GL_BYTE                          0x1400
+#define GL_UNSIGNED_BYTE                 0x1401
+#define GL_UNSIGNED_SHORT                0x1403
+#define GL_INT                           0x1404
+#define GL_FLOAT                         0x1406
+#define GL_UNSIGNED_SHORT_5_6_5          0x8363
+#define GL_UNSIGNED_INT_24_8             0x84FA
+#define GL_TRIANGLES                     0x0004
+#define GL_TRIANGLE_FAN                  0x0006
+#define GL_EQUAL                         0x0202
+#define GL_LESS                          0x0201
+#define GL_ALWAYS                        0x0207
+#define GL_FRONT_AND_BACK                0x0408
+#define GL_KEEP                          0x1E00
+#define GL_REPLACE                       0x1E01
+#define GL_FILL                          0x1B02
+#define GL_COLOR_BUFFER_BIT              0x00004000
+#define GL_DEPTH_BUFFER_BIT              0x00000100
+#define GL_STENCIL_BUFFER_BIT            0x00000400
+#define GL_TEXTURE_2D                    0x0DE1
+#define GL_TEXTURE_MAG_FILTER            0x2800
+#define GL_TEXTURE_MIN_FILTER            0x2801
+#define GL_TEXTURE_WRAP_S                0x2802
+#define GL_TEXTURE_WRAP_T                0x2803
+#define GL_NEAREST                       0x2600
+#define GL_CLAMP_TO_EDGE                 0x812F
+#define GL_ARRAY_BUFFER                  0x8892
+#define GL_PIXEL_PACK_BUFFER             0x88EB
+#define GL_PIXEL_UNPACK_BUFFER           0x88EC
+#define GL_STATIC_DRAW                   0x88E4
+#define GL_SCISSOR_TEST                  0x0C11
+#define GL_DEPTH_TEST                    0x0B71
+#define GL_STENCIL_TEST                  0x0B90
+#define GL_BLEND                         0x0BE2
+#define GL_CULL_FACE                     0x0B44
+#define GL_DITHER                        0x0BD0
+#define GL_COLOR_LOGIC_OP                0x0BF2
+#define GL_RASTERIZER_DISCARD            0x8C89
+#define GL_FRAMEBUFFER_SRGB              0x8DB9
+#define GL_PACK_SWAP_BYTES               0x0D00
+#define GL_PACK_LSB_FIRST                0x0D01
+#define GL_PACK_ROW_LENGTH               0x0D02
+#define GL_PACK_SKIP_ROWS                0x0D03
+#define GL_PACK_SKIP_PIXELS              0x0D04
+#define GL_PACK_ALIGNMENT                0x0D05
+#define GL_PACK_SKIP_IMAGES              0x806B
+#define GL_PACK_IMAGE_HEIGHT             0x806C
+#define GL_UNPACK_SWAP_BYTES             0x0CF0
+#define GL_UNPACK_LSB_FIRST              0x0CF1
+#define GL_UNPACK_ROW_LENGTH             0x0CF2
+#define GL_UNPACK_SKIP_ROWS              0x0CF3
+#define GL_UNPACK_SKIP_PIXELS            0x0CF4
+#define GL_UNPACK_ALIGNMENT              0x0CF5
+#define GL_UNPACK_SKIP_IMAGES            0x806D
+#define GL_UNPACK_IMAGE_HEIGHT           0x806E
+#define GL_RGB                           0x1907
+#define GL_RGBA                          0x1908
+#define GL_RGB565                        0x8D62
+#define GL_RGB16F                        0x881B
+#define GL_COLOR                         0x1800
+#define GL_VERSION                       0x1F02
+#define GL_TEXTURE0                      0x84C0
+#define GL_TEXTURE1                      0x84C1
+#define GL_RED_INTEGER                   0x8D94
+#define GL_RGBA_INTEGER                  0x8D99
+#define GL_R16UI                         0x8234
+#define GL_RGBA8I                        0x8D8E
+#define GL_DEPTH_STENCIL                 0x84F9
+#define GL_DEPTH24_STENCIL8              0x88F0
+#define GL_FRAMEBUFFER                   0x8D40
+#define GL_READ_FRAMEBUFFER              0x8CA8
+#define GL_DRAW_FRAMEBUFFER              0x8CA9
+#define GL_FRAMEBUFFER_COMPLETE          0x8CD5
+#define GL_COLOR_ATTACHMENT0             0x8CE0
+#define GL_COLOR_ATTACHMENT1             0x8CE1
+#define GL_COLOR_ATTACHMENT2             0x8CE2
+#define GL_DEPTH_STENCIL_ATTACHMENT      0x821A
+#define GL_FRAGMENT_SHADER               0x8B30
+#define GL_VERTEX_SHADER                 0x8B31
+#define GL_COMPILE_STATUS                0x8B81
+#define GL_LINK_STATUS                   0x8B82
+
+#define M_GBA_GL_FUNCTIONS(F) \
+	F(void, glActiveTexture, (GLenum texture)) \
+	F(void, glAttachShader, (GLuint program, GLuint shader)) \
+	F(void, glBindBuffer, (GLenum target, GLuint buffer)) \
+	F(void, glBindSampler, (GLuint unit, GLuint sampler)) \
+	F(void, glBindFramebuffer, (GLenum target, GLuint framebuffer)) \
+	F(void, glBindTexture, (GLenum target, GLuint texture)) \
+	F(void, glBindVertexArray, (GLuint array)) \
+	F(void, glBlitFramebuffer, (GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, \
+		GLint dstX0, GLint dstY0, GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter)) \
+	F(void, glBufferData, (GLenum target, GLsizeiptr size, const void* data, GLenum usage)) \
+	F(GLenum, glCheckFramebufferStatus, (GLenum target)) \
+	F(void, glClear, (GLbitfield mask)) \
+	F(void, glClearBufferiv, (GLenum buffer, GLint drawbuffer, const GLint* value)) \
+	F(void, glClearColor, (GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha)) \
+	F(void, glClearDepth, (GLdouble depth)) \
+	F(void, glClearStencil, (GLint s)) \
+	F(void, glColorMask, (GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha)) \
+	F(void, glCompileShader, (GLuint shader)) \
+	F(GLuint, glCreateProgram, (void)) \
+	F(GLuint, glCreateShader, (GLenum type)) \
+	F(void, glDeleteBuffers, (GLsizei n, const GLuint* buffers)) \
+	F(void, glDeleteFramebuffers, (GLsizei n, const GLuint* framebuffers)) \
+	F(void, glDeleteProgram, (GLuint program)) \
+	F(void, glDeleteShader, (GLuint shader)) \
+	F(void, glDeleteTextures, (GLsizei n, const GLuint* textures)) \
+	F(void, glDeleteVertexArrays, (GLsizei n, const GLuint* arrays)) \
+	F(void, glDepthFunc, (GLenum func)) \
+	F(void, glDepthMask, (GLboolean flag)) \
+	F(void, glDepthRange, (GLdouble nearValue, GLdouble farValue)) \
+	F(void, glDisable, (GLenum cap)) \
+	F(void, glDrawArrays, (GLenum mode, GLint first, GLsizei count)) \
+	F(void, glDrawBuffers, (GLsizei n, const GLenum* bufs)) \
+	F(void, glEnable, (GLenum cap)) \
+	F(void, glEnableVertexAttribArray, (GLuint index)) \
+	F(void, glFinish, (void)) \
+	F(void, glFramebufferTexture2D, (GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level)) \
+	F(void, glGenBuffers, (GLsizei n, GLuint* buffers)) \
+	F(void, glGenFramebuffers, (GLsizei n, GLuint* framebuffers)) \
+	F(void, glGenTextures, (GLsizei n, GLuint* textures)) \
+	F(void, glGenVertexArrays, (GLsizei n, GLuint* arrays)) \
+	F(GLint, glGetAttribLocation, (GLuint program, const GLchar* name)) \
+	F(void, glGetProgramiv, (GLuint program, GLenum pname, GLint* params)) \
+	F(void, glGetProgramInfoLog, (GLuint program, GLsizei bufSize, GLsizei* length, GLchar* infoLog)) \
+	F(void, glGetShaderiv, (GLuint shader, GLenum pname, GLint* params)) \
+	F(void, glGetShaderInfoLog, (GLuint shader, GLsizei bufSize, GLsizei* length, GLchar* infoLog)) \
+	F(const GLubyte*, glGetString, (GLenum name)) \
+	F(GLint, glGetUniformLocation, (GLuint program, const GLchar* name)) \
+	F(void, glLinkProgram, (GLuint program)) \
+	F(void, glPixelStorei, (GLenum pname, GLint param)) \
+	F(void, glPolygonMode, (GLenum face, GLenum mode)) \
+	F(void, glReadPixels, (GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, void* data)) \
+	F(void, glScissor, (GLint x, GLint y, GLsizei width, GLsizei height)) \
+	F(void, glShaderSource, (GLuint shader, GLsizei count, const GLchar* const* string, const GLint* length)) \
+	F(void, glStencilFunc, (GLenum func, GLint ref, GLuint mask)) \
+	F(void, glStencilMask, (GLuint mask)) \
+	F(void, glStencilOp, (GLenum sfail, GLenum dpfail, GLenum dppass)) \
+	F(void, glTexImage2D, (GLenum target, GLint level, GLint internalformat, GLsizei width, \
+		GLsizei height, GLint border, GLenum format, GLenum type, const void* pixels)) \
+	F(void, glTexParameteri, (GLenum target, GLenum pname, GLint param)) \
+	F(void, glTexSubImage2D, (GLenum target, GLint level, GLint xoffset, GLint yoffset, \
+		GLsizei width, GLsizei height, GLenum format, GLenum type, const void* pixels)) \
+	F(void, glUniform1i, (GLint location, GLint v0)) \
+	F(void, glUniform1iv, (GLint location, GLsizei count, const GLint* value)) \
+	F(void, glUniform2i, (GLint location, GLint v0, GLint v1)) \
+	F(void, glUniform3f, (GLint location, GLfloat v0, GLfloat v1, GLfloat v2)) \
+	F(void, glUniform3i, (GLint location, GLint v0, GLint v1, GLint v2)) \
+	F(void, glUniform4i, (GLint location, GLint v0, GLint v1, GLint v2, GLint v3)) \
+	F(void, glUniform4iv, (GLint location, GLsizei count, const GLint* value)) \
+	F(void, glUniformMatrix2fv, (GLint location, GLsizei count, GLboolean transpose, const GLfloat* value)) \
+	F(void, glUseProgram, (GLuint program)) \
+	F(void, glVertexAttribPointer, (GLuint index, GLint size, GLenum type, GLboolean normalized, \
+		GLsizei stride, const void* pointer)) \
+	F(void, glViewport, (GLint x, GLint y, GLsizei width, GLsizei height))
+
+#define M_GBA_GL_DECLARE(ret, name, args) \
+	typedef ret (M_GBA_GL_APIENTRY *mGBA##name##Proc) args; \
+	extern mGBA##name##Proc mGBA##name;
+M_GBA_GL_FUNCTIONS(M_GBA_GL_DECLARE)
+#undef M_GBA_GL_DECLARE
+
+#define glActiveTexture mGBAglActiveTexture
+#define glAttachShader mGBAglAttachShader
+#define glBindBuffer mGBAglBindBuffer
+#define glBindSampler mGBAglBindSampler
+#define glBindFramebuffer mGBAglBindFramebuffer
+#define glBindTexture mGBAglBindTexture
+#define glBindVertexArray mGBAglBindVertexArray
+#define glBlitFramebuffer mGBAglBlitFramebuffer
+#define glBufferData mGBAglBufferData
+#define glCheckFramebufferStatus mGBAglCheckFramebufferStatus
+#define glClear mGBAglClear
+#define glClearBufferiv mGBAglClearBufferiv
+#define glClearColor mGBAglClearColor
+#define glClearDepth mGBAglClearDepth
+#define glClearStencil mGBAglClearStencil
+#define glColorMask mGBAglColorMask
+#define glCompileShader mGBAglCompileShader
+#define glCreateProgram mGBAglCreateProgram
+#define glCreateShader mGBAglCreateShader
+#define glDeleteBuffers mGBAglDeleteBuffers
+#define glDeleteFramebuffers mGBAglDeleteFramebuffers
+#define glDeleteProgram mGBAglDeleteProgram
+#define glDeleteShader mGBAglDeleteShader
+#define glDeleteTextures mGBAglDeleteTextures
+#define glDeleteVertexArrays mGBAglDeleteVertexArrays
+#define glDepthFunc mGBAglDepthFunc
+#define glDepthMask mGBAglDepthMask
+#define glDepthRange mGBAglDepthRange
+#define glDisable mGBAglDisable
+#define glDrawArrays mGBAglDrawArrays
+#define glDrawBuffers mGBAglDrawBuffers
+#define glEnable mGBAglEnable
+#define glEnableVertexAttribArray mGBAglEnableVertexAttribArray
+#define glFinish mGBAglFinish
+#define glFramebufferTexture2D mGBAglFramebufferTexture2D
+#define glGenBuffers mGBAglGenBuffers
+#define glGenFramebuffers mGBAglGenFramebuffers
+#define glGenTextures mGBAglGenTextures
+#define glGenVertexArrays mGBAglGenVertexArrays
+#define glGetAttribLocation mGBAglGetAttribLocation
+#define glGetProgramiv mGBAglGetProgramiv
+#define glGetProgramInfoLog mGBAglGetProgramInfoLog
+#define glGetShaderiv mGBAglGetShaderiv
+#define glGetShaderInfoLog mGBAglGetShaderInfoLog
+#define glGetString mGBAglGetString
+#define glGetUniformLocation mGBAglGetUniformLocation
+#define glLinkProgram mGBAglLinkProgram
+#define glPixelStorei mGBAglPixelStorei
+#define glPolygonMode mGBAglPolygonMode
+#define glReadPixels mGBAglReadPixels
+#define glScissor mGBAglScissor
+#define glShaderSource mGBAglShaderSource
+#define glStencilFunc mGBAglStencilFunc
+#define glStencilMask mGBAglStencilMask
+#define glStencilOp mGBAglStencilOp
+#define glTexImage2D mGBAglTexImage2D
+#define glTexParameteri mGBAglTexParameteri
+#define glTexSubImage2D mGBAglTexSubImage2D
+#define glUniform1i mGBAglUniform1i
+#define glUniform1iv mGBAglUniform1iv
+#define glUniform2i mGBAglUniform2i
+#define glUniform3f mGBAglUniform3f
+#define glUniform3i mGBAglUniform3i
+#define glUniform4i mGBAglUniform4i
+#define glUniform4iv mGBAglUniform4iv
+#define glUniformMatrix2fv mGBAglUniformMatrix2fv
+#define glUseProgram mGBAglUseProgram
+#define glVertexAttribPointer mGBAglVertexAttribPointer
+#define glViewport mGBAglViewport
+
+#undef M_GBA_GL_APIENTRY
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/mgba/internal/gba/renderers/gl.h
+++ b/include/mgba/internal/gba/renderers/gl.h
@@ -18,7 +18,9 @@ CXX_GUARD_START
 
 #ifdef BUILD_GLES3
 
-#ifdef USE_EPOXY
+#ifdef LIBRETRO_OPENGL
+#include <mgba/internal/gba/renderers/gl-dispatch.h>
+#elif defined(USE_EPOXY)
 #include <epoxy/gl.h>
 #elif defined(__APPLE__)
 #include <OpenGL/gl3.h>

--- a/include/mgba/internal/gba/video.h
+++ b/include/mgba/internal/gba/video.h
@@ -237,6 +237,8 @@ void GBAVideoDeinit(struct GBAVideo* video);
 
 void GBAVideoDummyRendererCreate(struct GBAVideoRenderer*);
 void GBAVideoAssociateRenderer(struct GBAVideo* video, struct GBAVideoRenderer* renderer);
+/* Switch renderers without deinitializing GL objects from a dead context. */
+void GBAVideoAssociateRendererAfterContextLoss(struct GBAVideo* video, struct GBAVideoRenderer* renderer);
 
 void GBAVideoWriteDISPSTAT(struct GBAVideo* video, uint16_t value);
 

--- a/libretro-build/Makefile.common
+++ b/libretro-build/Makefile.common
@@ -13,6 +13,10 @@ ifneq ($(TARGET_PLATFORM), android_arm64-v8a)
 	RETRODEFS += -DSSIZE_MAX=2147483648
 endif
 
+ifeq ($(HAVE_OPENGL),1)
+RETRODEFS += -DBUILD_GLES3 -DBUILD_GL -DLIBRETRO_OPENGL
+endif
+
 ifeq ($(STATIC_LINKING), 1)
 INCLUDES += -I$(CORE_DIR)/src/third-party/zlib \
 				-I$(CORE_DIR)/libretro-build/include/libz
@@ -137,6 +141,13 @@ SOURCES_C :=   $(CORE_DIR)/src/arm/arm.c \
 					$(CORE_DIR)/src/util/vfs.c \
 					$(CORE_DIR)/src/util/vfs/vfs-mem.c \
 					$(CORE_DIR)/src/util/crc32.c
+
+ifeq ($(HAVE_OPENGL),1)
+SOURCES_C += $(CORE_DIR)/src/gba/renderers/gl.c \
+             $(CORE_DIR)/src/platform/libretro/libretro_gl.c \
+             $(CORE_DIR)/src/platform/libretro/libretro_video_gl.c \
+             $(CORE_DIR)/src/platform/libretro/libretro_video_gl_postprocess.c
+endif
 
 ifeq ($(STATIC_LINKING), 1)
 RETRODEFS += -DHAVE_CRC32

--- a/src/gba/core.c
+++ b/src/gba/core.c
@@ -553,6 +553,39 @@ static void _GBACoreSetVideoGLTex(struct mCore* core, unsigned texid) {
 #endif
 }
 
+void GBACoreInvalidateVideoGLContext(struct mCore* core) {
+#ifdef BUILD_GLES3
+	struct GBACore* gbacore;
+	struct GBA* gba;
+	struct GBAVideoRenderer* fallback;
+
+	if (!core) {
+		return;
+	}
+	gbacore = (struct GBACore*) core;
+	gba = core->board;
+	if (!gba || gba->video.renderer != &gbacore->glRenderer.d) {
+		return;
+	}
+
+	if (gbacore->glRenderer.temporaryBuffer) {
+		mappedMemoryFree(gbacore->glRenderer.temporaryBuffer,
+			GBA_VIDEO_HORIZONTAL_PIXELS * GBA_VIDEO_VERTICAL_PIXELS *
+			gbacore->glRenderer.scale * gbacore->glRenderer.scale * BYTES_PER_PIXEL);
+		gbacore->glRenderer.temporaryBuffer = NULL;
+	}
+
+	fallback = gbacore->renderer.outputBuffer
+		? &gbacore->renderer.d
+		: &gbacore->dummyRenderer;
+	GBAVideoAssociateRendererAfterContextLoss(&gba->video, fallback);
+	GBAVideoGLRendererCreate(&gbacore->glRenderer);
+	gbacore->glRenderer.outputTex = (unsigned) -1;
+#else
+	UNUSED(core);
+#endif
+}
+
 static void _GBACoreGetPixels(struct mCore* core, const void** buffer, size_t* stride) {
 	struct GBA* gba = core->board;
 	gba->video.renderer->getPixels(gba->video.renderer, stride, buffer);

--- a/src/gba/video.c
+++ b/src/gba/video.c
@@ -114,9 +114,11 @@ void GBAVideoDummyRendererCreate(struct GBAVideoRenderer* renderer) {
 	memcpy(renderer, &dummyRenderer, sizeof(*renderer));
 }
 
-void GBAVideoAssociateRenderer(struct GBAVideo* video, struct GBAVideoRenderer* renderer) {
+static void _GBAVideoAssociateRenderer(struct GBAVideo* video, struct GBAVideoRenderer* renderer, bool deinitPrevious) {
 	if (video->renderer) {
-		video->renderer->deinit(video->renderer);
+		if (deinitPrevious) {
+			video->renderer->deinit(video->renderer);
+		}
 		renderer->cache = video->renderer->cache;
 	} else {
 		renderer->cache = NULL;
@@ -136,6 +138,14 @@ void GBAVideoAssociateRenderer(struct GBAVideo* video, struct GBAVideoRenderer* 
 		}
 		renderer->writeVideoRegister(renderer, address, video->p->memory.io[address >> 1]);
 	}
+}
+
+void GBAVideoAssociateRenderer(struct GBAVideo* video, struct GBAVideoRenderer* renderer) {
+	_GBAVideoAssociateRenderer(video, renderer, true);
+}
+
+void GBAVideoAssociateRendererAfterContextLoss(struct GBAVideo* video, struct GBAVideoRenderer* renderer) {
+	_GBAVideoAssociateRenderer(video, renderer, false);
 }
 
 void _startHdraw(struct mTiming* timing, void* context, uint32_t cyclesLate) {

--- a/src/platform/libretro/libretro.c
+++ b/src/platform/libretro/libretro.c
@@ -28,6 +28,10 @@
 #include <mgba-util/memory.h>
 #include <mgba-util/vfs.h>
 
+#ifdef LIBRETRO_OPENGL
+#include "libretro_video_gl.h"
+#endif
+
 #ifndef __LIBRETRO__
 #error "Can't compile the libretro core as anything other than libretro."
 #endif
@@ -560,6 +564,27 @@ enum frame_blend_method
 
 static enum frame_blend_method frameBlendType = FRAME_BLEND_NONE;
 static bool frameBlendEnabled                 = false;
+#if defined(LIBRETRO_OPENGL) && defined(COLOR_16_BIT) && defined(COLOR_5_6_5)
+static enum mLibretroVideoGLFrameBlend _libretroVideoGLFrameBlend(void) {
+	if (!frameBlendEnabled) {
+		return mLIBRETRO_VIDEO_GL_FRAME_BLEND_NONE;
+	}
+
+	switch (frameBlendType) {
+	case FRAME_BLEND_MIX:
+		return mLIBRETRO_VIDEO_GL_FRAME_BLEND_MIX;
+	case FRAME_BLEND_MIX_SMART:
+		return mLIBRETRO_VIDEO_GL_FRAME_BLEND_MIX_SMART;
+	case FRAME_BLEND_LCD_GHOSTING:
+		return mLIBRETRO_VIDEO_GL_FRAME_BLEND_LCD_GHOSTING;
+	case FRAME_BLEND_LCD_GHOSTING_FAST:
+		return mLIBRETRO_VIDEO_GL_FRAME_BLEND_LCD_GHOSTING_FAST;
+	case FRAME_BLEND_NONE:
+	default:
+		return mLIBRETRO_VIDEO_GL_FRAME_BLEND_NONE;
+	}
+}
+#endif
 static mColor* outputBufferPrev1              = NULL;
 static mColor* outputBufferPrev2              = NULL;
 static mColor* outputBufferPrev3              = NULL;
@@ -1355,15 +1380,21 @@ void retro_get_system_info(struct retro_system_info* info) {
 
 void retro_get_system_av_info(struct retro_system_av_info* info) {
 	unsigned width, height;
+	unsigned maxWidth, maxHeight;
+
 	core->currentVideoSize(core, &width, &height);
+	core->baseVideoSize(core, &maxWidth, &maxHeight);
+#ifdef LIBRETRO_OPENGL
+	if (mLibretroVideoGLGetSize(core, &width, &height)) {
+		maxWidth = width;
+		maxHeight = height;
+	}
+#endif
 	info->geometry.base_width = width;
 	info->geometry.base_height = height;
-
-	core->baseVideoSize(core, &width, &height);
-	info->geometry.max_width = width;
-	info->geometry.max_height = height;
-
-	info->geometry.aspect_ratio = width / (double) height;
+	info->geometry.max_width = maxWidth;
+	info->geometry.max_height = maxHeight;
+	info->geometry.aspect_ratio = maxWidth / (double) maxHeight;
 	info->timing.fps = core->frequency(core) / (float) core->frameCycles(core);
 
 #ifdef M_CORE_GBA
@@ -1473,9 +1504,15 @@ void retro_init(void) {
 	retroAudioLatency       = 0;
 	updateAudioLatency      = false;
 	updateAudioRate         = false;
+#ifdef LIBRETRO_OPENGL
+	mLibretroVideoGLInit(environCallback, logCallback);
+#endif
 }
 
 void retro_deinit(void) {
+#ifdef LIBRETRO_OPENGL
+	mLibretroVideoGLDeinit();
+#endif
 	if (outputBuffer) {
 #ifdef _3DS
 		linearFree(outputBuffer);
@@ -1548,6 +1585,9 @@ int16_t cycleturbo(bool a, bool b, bool l, bool r) {
 }
 
 void retro_run(void) {
+#ifdef LIBRETRO_OPENGL
+	mLibretroVideoGLBeginFrame();
+#endif
 	if (deferredSetup) {
 		_doDeferredSetup();
 	}
@@ -1707,15 +1747,41 @@ void retro_run(void) {
 	}
 
 	if (!skipFrame) {
+#ifdef LIBRETRO_OPENGL
+		if (mLibretroVideoGLIsRequested()) {
+			const struct mLibretroVideoGLPostProcessing* postProcessing = NULL;
 #if defined(COLOR_16_BIT) && defined(COLOR_5_6_5)
-		if (videoPostProcess) {
-			videoPostProcess(width, height);
-			videoCallback(ppOutputBuffer, width, height, VIDEO_WIDTH_MAX * sizeof(mColor));
+			const struct mLibretroVideoGLPostProcessing settings = {
+				.colorCorrectionEnabled = colorCorrectionEnabled,
+				.colorCorrectionLut = (const uint16_t*) ccLUT,
+				.colorCorrectionType = ccType,
+				.frameBlend = _libretroVideoGLFrameBlend(),
+			};
+			postProcessing = &settings;
+#endif
+			if (mLibretroVideoGLPresent(width, height, postProcessing)) {
+				videoCallback(RETRO_HW_FRAME_BUFFER_VALID, width, height, 0);
+			} else {
+				videoCallback(NULL, width, height, 0);
+			}
 		} else
 #endif
-			videoCallback(outputBuffer, width, height, VIDEO_WIDTH_MAX * sizeof(mColor));
+		{
+#if defined(COLOR_16_BIT) && defined(COLOR_5_6_5)
+			if (videoPostProcess) {
+				videoPostProcess(width, height);
+				videoCallback(ppOutputBuffer, width, height, VIDEO_WIDTH_MAX * sizeof(mColor));
+			} else
+#endif
+				videoCallback(outputBuffer, width, height, VIDEO_WIDTH_MAX * sizeof(mColor));
+		}
 	} else {
+#ifdef LIBRETRO_OPENGL
+		videoCallback(NULL, width, height,
+			mLibretroVideoGLIsRequested() ? 0 : VIDEO_WIDTH_MAX * sizeof(mColor));
+#else
 		videoCallback(NULL, width, height, VIDEO_WIDTH_MAX * sizeof(mColor));
+#endif
 	}
 
 	/* Check whether audio sample rate has changed */
@@ -2085,6 +2151,11 @@ bool retro_load_game(const struct retro_game_info* game) {
 	memset(savedata, 0xFF, GBA_SIZE_FLASH1M);
 
 	_reloadSettings();
+#ifdef LIBRETRO_OPENGL
+	if (core->platform(core) == mPLATFORM_GBA) {
+		mLibretroVideoGLRequest(core);
+	}
+#endif
 	core->loadROM(core, rom);
 	deferredSetup = true;
 
@@ -2154,8 +2225,12 @@ void retro_unload_game(void) {
 	if (!core) {
 		return;
 	}
+#ifdef LIBRETRO_OPENGL
+	mLibretroVideoGLDeinit();
+#endif
 	mCoreConfigDeinit(&core->config);
 	core->deinit(core);
+	core = NULL;
 	mappedMemoryFree(data, dataSize);
 	data = 0;
 	mappedMemoryFree(savedata, GBA_SIZE_FLASH1M);

--- a/src/platform/libretro/libretro_core_options.h
+++ b/src/platform/libretro/libretro_core_options.h
@@ -208,6 +208,50 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "OFF"
    },
 #endif
+#ifdef LIBRETRO_OPENGL
+   {
+      "mgba_renderer",
+      "Renderer (Restart)",
+      NULL,
+      "Selects the software renderer or the OpenGL high-resolution renderer. OpenGL is available for Game Boy Advance content only and requires an OpenGL 3.3-compatible frontend video driver.",
+      NULL,
+      "video",
+      {
+         { "software", "Software" },
+         { "opengl",   "OpenGL (High Resolution)" },
+         { NULL, NULL },
+      },
+      "software"
+   },
+   {
+      "mgba_opengl_scale",
+      "OpenGL Internal Resolution (Restart)",
+      NULL,
+      "Sets the internal resolution multiplier used by mGBA's OpenGL renderer. Native GBA resolution is 240x160.",
+      NULL,
+      "video",
+      {
+         { "1",  "1x (240x160)" },
+         { "2",  "2x (480x320)" },
+         { "3",  "3x (720x480)" },
+         { "4",  "4x (960x640)" },
+         { "5",  "5x (1200x800)" },
+         { "6",  "6x (1440x960)" },
+         { "7",  "7x (1680x1120)" },
+         { "8",  "8x (1920x1280)" },
+         { "9",  "9x (2160x1440)" },
+         { "10", "10x (2400x1600)" },
+         { "11", "11x (2640x1760)" },
+         { "12", "12x (2880x1920)" },
+         { "13", "13x (3120x2080)" },
+         { "14", "14x (3360x2240)" },
+         { "15", "15x (3600x2400)" },
+         { "16", "16x (3840x2560)" },
+         { NULL, NULL },
+      },
+      "1"
+   },
+#endif
    {
       "mgba_audio_low_pass_filter",
       "Audio Filter",

--- a/src/platform/libretro/libretro_gl.c
+++ b/src/platform/libretro/libretro_gl.c
@@ -1,0 +1,94 @@
+/* Copyright (c) 2013-2026 mGBA contributors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+#include "libretro_gl.h"
+
+#include <string.h>
+
+#define M_GBA_GL_DEFINE(ret, name, args) mGBA##name##Proc mGBA##name = NULL;
+M_GBA_GL_FUNCTIONS(M_GBA_GL_DEFINE)
+#undef M_GBA_GL_DEFINE
+
+static const char* s_missingSymbol;
+
+bool mLibretroGLLoad(retro_hw_get_proc_address_t getProcAddress) {
+	mLibretroGLUnload();
+	if (!getProcAddress) {
+		s_missingSymbol = "get_proc_address";
+		return false;
+	}
+
+	s_missingSymbol = NULL;
+#define M_GBA_GL_LOAD(ret, name, args) \
+	do { \
+		retro_proc_address_t proc = getProcAddress(#name); \
+		if (!proc || sizeof(mGBA##name) != sizeof(proc)) { \
+			s_missingSymbol = #name; \
+			mLibretroGLUnload(); \
+			return false; \
+		} \
+		memcpy(&mGBA##name, &proc, sizeof(mGBA##name)); \
+	} while (0);
+	M_GBA_GL_FUNCTIONS(M_GBA_GL_LOAD)
+#undef M_GBA_GL_LOAD
+	return true;
+}
+
+void mLibretroGLUnload(void) {
+#define M_GBA_GL_CLEAR(ret, name, args) mGBA##name = NULL;
+	M_GBA_GL_FUNCTIONS(M_GBA_GL_CLEAR)
+#undef M_GBA_GL_CLEAR
+}
+
+const char* mLibretroGLMissingSymbol(void) {
+	return s_missingSymbol;
+}
+
+void mLibretroGLResetState(void) {
+	unsigned unit;
+
+	glDisable(GL_BLEND);
+	glDisable(GL_COLOR_LOGIC_OP);
+	glDisable(GL_CULL_FACE);
+	glDisable(GL_DEPTH_TEST);
+	glDisable(GL_DITHER);
+	glDisable(GL_FRAMEBUFFER_SRGB);
+	glDisable(GL_RASTERIZER_DISCARD);
+	glDisable(GL_SCISSOR_TEST);
+	glDisable(GL_STENCIL_TEST);
+	glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+	glDepthMask(GL_TRUE);
+	glDepthRange(0.0, 1.0);
+	glStencilMask(~0U);
+	glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+	glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+	glUseProgram(0);
+	glBindVertexArray(0);
+	glBindBuffer(GL_ARRAY_BUFFER, 0);
+	glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+	glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+	for (unit = 0; unit <= 8; ++unit) {
+		glActiveTexture(GL_TEXTURE0 + unit);
+		glBindTexture(GL_TEXTURE_2D, 0);
+		glBindSampler(unit, 0);
+	}
+	glActiveTexture(GL_TEXTURE0);
+	glPixelStorei(GL_PACK_SWAP_BYTES, GL_FALSE);
+	glPixelStorei(GL_PACK_LSB_FIRST, GL_FALSE);
+	glPixelStorei(GL_PACK_ROW_LENGTH, 0);
+	glPixelStorei(GL_PACK_SKIP_ROWS, 0);
+	glPixelStorei(GL_PACK_SKIP_PIXELS, 0);
+	glPixelStorei(GL_PACK_SKIP_IMAGES, 0);
+	glPixelStorei(GL_PACK_IMAGE_HEIGHT, 0);
+	glPixelStorei(GL_PACK_ALIGNMENT, 4);
+	glPixelStorei(GL_UNPACK_SWAP_BYTES, GL_FALSE);
+	glPixelStorei(GL_UNPACK_LSB_FIRST, GL_FALSE);
+	glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+	glPixelStorei(GL_UNPACK_SKIP_ROWS, 0);
+	glPixelStorei(GL_UNPACK_SKIP_PIXELS, 0);
+	glPixelStorei(GL_UNPACK_SKIP_IMAGES, 0);
+	glPixelStorei(GL_UNPACK_IMAGE_HEIGHT, 0);
+	glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
+}

--- a/src/platform/libretro/libretro_gl.h
+++ b/src/platform/libretro/libretro_gl.h
@@ -1,0 +1,20 @@
+/* Copyright (c) 2013-2026 mGBA contributors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+#ifndef M_LIBRETRO_GL_H
+#define M_LIBRETRO_GL_H
+
+#include <stdbool.h>
+
+#include <mgba/internal/gba/renderers/gl-dispatch.h>
+
+#include "libretro.h"
+
+bool mLibretroGLLoad(retro_hw_get_proc_address_t getProcAddress);
+void mLibretroGLUnload(void);
+const char* mLibretroGLMissingSymbol(void);
+void mLibretroGLResetState(void);
+
+#endif

--- a/src/platform/libretro/libretro_video_gl.c
+++ b/src/platform/libretro/libretro_video_gl.c
@@ -1,0 +1,287 @@
+/* Copyright (c) 2013-2026 mGBA contributors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+#include "libretro_video_gl.h"
+
+#include <mgba/core/core.h>
+#include <mgba/gba/core.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "libretro_gl.h"
+#include "libretro_video_gl_postprocess.h"
+
+struct mLibretroVideoGLState {
+	retro_environment_t environment;
+	retro_log_printf_t logCallback;
+	struct mCore* core;
+	struct retro_hw_render_callback callback;
+	GLuint outputTexture;
+	GLuint outputFramebuffer;
+	unsigned scale;
+	bool requested;
+	bool dispatchLoaded;
+	bool contextReady;
+	bool rendererEnabled;
+};
+
+static struct mLibretroVideoGLState s_video;
+
+static void _contextReset(void);
+static void _contextDestroy(void);
+
+static unsigned _readScale(void) {
+	struct retro_variable variable = {
+		.key = "mgba_opengl_scale",
+		.value = NULL,
+	};
+	long scale;
+
+	if (!s_video.environment ||
+			!s_video.environment(RETRO_ENVIRONMENT_GET_VARIABLE, &variable) ||
+			!variable.value) {
+		return 1;
+	}
+
+	scale = strtol(variable.value, NULL, 10);
+	return scale >= 1 && scale <= 16 ? (unsigned) scale : 1;
+}
+
+static void _releaseContext(bool contextValid) {
+	mLibretroVideoGLPostProcessDestroy(contextValid && s_video.dispatchLoaded);
+
+	if (s_video.core && s_video.rendererEnabled &&
+			s_video.core->platform(s_video.core) == mPLATFORM_GBA) {
+		if (contextValid) {
+			mCoreConfigSetIntValue(&s_video.core->config, "hwaccelVideo", 0);
+			s_video.core->reloadConfigOption(s_video.core, "hwaccelVideo", NULL);
+		} else {
+			GBACoreInvalidateVideoGLContext(s_video.core);
+		}
+		s_video.core->setVideoGLTex(s_video.core, (unsigned) -1);
+	}
+
+	if (contextValid && s_video.dispatchLoaded) {
+		if (s_video.outputFramebuffer) {
+			glDeleteFramebuffers(1, &s_video.outputFramebuffer);
+		}
+		if (s_video.outputTexture) {
+			glDeleteTextures(1, &s_video.outputTexture);
+		}
+	}
+
+	s_video.outputFramebuffer = 0;
+	s_video.outputTexture = 0;
+	s_video.contextReady = false;
+	s_video.rendererEnabled = false;
+	if (s_video.dispatchLoaded) {
+		mLibretroGLUnload();
+		s_video.dispatchLoaded = false;
+	}
+}
+
+static void _contextReset(void) {
+	GLuint frontendFramebuffer;
+	const GLubyte* version;
+
+	if (!s_video.requested || !s_video.core ||
+			s_video.core->platform(s_video.core) != mPLATFORM_GBA) {
+		return;
+	}
+
+	/* A frontend may replace a context without delivering context_destroy.
+	 * Old object names must then be abandoned, not deleted in the new context. */
+	if (s_video.contextReady || s_video.rendererEnabled || s_video.dispatchLoaded) {
+		_releaseContext(false);
+	}
+
+	if (!mLibretroGLLoad(s_video.callback.get_proc_address)) {
+		if (s_video.logCallback) {
+			s_video.logCallback(RETRO_LOG_ERROR,
+				"OpenGL high-resolution renderer unavailable: missing GL entry point '%s'. "
+				"Restart content with the software renderer.\n",
+				mLibretroGLMissingSymbol() ? mLibretroGLMissingSymbol() : "unknown");
+		}
+		return;
+	}
+	s_video.dispatchLoaded = true;
+
+	if (!s_video.callback.get_current_framebuffer) {
+		if (s_video.logCallback) {
+			s_video.logCallback(RETRO_LOG_ERROR,
+				"OpenGL high-resolution renderer unavailable: frontend did not provide get_current_framebuffer.\n");
+		}
+		_releaseContext(false);
+		return;
+	}
+
+	mLibretroGLResetState();
+	glGenTextures(1, &s_video.outputTexture);
+	if (!s_video.outputTexture) {
+		if (s_video.logCallback) {
+			s_video.logCallback(RETRO_LOG_ERROR,
+				"OpenGL high-resolution renderer could not create its output texture.\n");
+		}
+		_releaseContext(true);
+		return;
+	}
+
+	s_video.core->setVideoGLTex(s_video.core, s_video.outputTexture);
+	mCoreConfigSetIntValue(&s_video.core->config, "videoScale", (int) s_video.scale);
+	mCoreConfigSetIntValue(&s_video.core->config, "hwaccelVideo", 1);
+	s_video.core->reloadConfigOption(s_video.core, "hwaccelVideo", NULL);
+	s_video.rendererEnabled = true;
+
+	glGenFramebuffers(1, &s_video.outputFramebuffer);
+	if (!s_video.outputFramebuffer) {
+		if (s_video.logCallback) {
+			s_video.logCallback(RETRO_LOG_ERROR,
+				"OpenGL high-resolution renderer could not create its output framebuffer.\n");
+		}
+		_releaseContext(true);
+		return;
+	}
+	glBindFramebuffer(GL_FRAMEBUFFER, s_video.outputFramebuffer);
+	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+		GL_TEXTURE_2D, s_video.outputTexture, 0);
+	if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+		if (s_video.logCallback) {
+			s_video.logCallback(RETRO_LOG_ERROR,
+				"OpenGL high-resolution renderer produced an incomplete output framebuffer.\n");
+		}
+		_releaseContext(true);
+		return;
+	}
+
+	if (!mLibretroVideoGLPostProcessCreate() && s_video.logCallback) {
+		s_video.logCallback(RETRO_LOG_WARN,
+			"OpenGL color correction and interframe blending are unavailable; "
+			"high-resolution rendering will continue without post-processing.\n");
+	}
+
+	s_video.contextReady = true;
+	frontendFramebuffer = (GLuint) s_video.callback.get_current_framebuffer();
+	mLibretroGLResetState();
+	glBindFramebuffer(GL_FRAMEBUFFER, frontendFramebuffer);
+
+	version = glGetString(GL_VERSION);
+	if (s_video.logCallback) {
+		s_video.logCallback(RETRO_LOG_INFO,
+			"mGBA OpenGL high-resolution renderer enabled at %ux (%s).\n",
+			s_video.scale, version ? (const char*) version : "unknown GL version");
+	}
+}
+
+static void _contextDestroy(void) {
+	_releaseContext(true);
+}
+
+void mLibretroVideoGLInit(retro_environment_t environment, retro_log_printf_t logCallback) {
+	memset(&s_video, 0, sizeof(s_video));
+	s_video.environment = environment;
+	s_video.logCallback = logCallback;
+	s_video.scale = 1;
+	mLibretroVideoGLPostProcessInit(logCallback);
+}
+
+bool mLibretroVideoGLRequest(struct mCore* core) {
+	struct retro_variable variable = {
+		.key = "mgba_renderer",
+		.value = NULL,
+	};
+
+	if (s_video.requested || s_video.contextReady || s_video.dispatchLoaded) {
+		mLibretroVideoGLDeinit();
+	}
+	s_video.core = core;
+
+	if (!s_video.environment || !core || core->platform(core) != mPLATFORM_GBA ||
+			!s_video.environment(RETRO_ENVIRONMENT_GET_VARIABLE, &variable) ||
+			!variable.value || strcmp(variable.value, "opengl") != 0) {
+		s_video.core = NULL;
+		return false;
+	}
+
+	s_video.scale = _readScale();
+	memset(&s_video.callback, 0, sizeof(s_video.callback));
+	s_video.callback.context_type = RETRO_HW_CONTEXT_OPENGL_CORE;
+	s_video.callback.context_reset = _contextReset;
+	s_video.callback.context_destroy = _contextDestroy;
+	s_video.callback.bottom_left_origin = false;
+	s_video.callback.version_major = 3;
+	s_video.callback.version_minor = 3;
+	s_video.callback.cache_context = false;
+
+	/* Set requested before SET_HW_RENDER: frontends may invoke context_reset
+	 * synchronously while processing the environment callback. */
+	s_video.requested = true;
+	if (!s_video.environment(RETRO_ENVIRONMENT_SET_HW_RENDER, &s_video.callback)) {
+		s_video.requested = false;
+		s_video.core = NULL;
+		if (s_video.logCallback) {
+			s_video.logCallback(RETRO_LOG_WARN,
+				"OpenGL high-resolution renderer unavailable: frontend rejected an "
+				"OpenGL 3.3 core context. Using software rendering.\n");
+		}
+		return false;
+	}
+	return true;
+}
+
+void mLibretroVideoGLDeinit(void) {
+	_releaseContext(true);
+	s_video.requested = false;
+	s_video.core = NULL;
+	s_video.scale = 1;
+	memset(&s_video.callback, 0, sizeof(s_video.callback));
+}
+
+bool mLibretroVideoGLIsRequested(void) {
+	return s_video.requested;
+}
+
+bool mLibretroVideoGLGetSize(const struct mCore* core, unsigned* width, unsigned* height) {
+	if (!s_video.requested || !core || core->platform(core) != mPLATFORM_GBA ||
+			!width || !height) {
+		return false;
+	}
+	core->baseVideoSize(core, width, height);
+	*width *= s_video.scale;
+	*height *= s_video.scale;
+	return true;
+}
+
+void mLibretroVideoGLBeginFrame(void) {
+	if (s_video.contextReady && s_video.rendererEnabled) {
+		mLibretroGLResetState();
+	}
+}
+
+bool mLibretroVideoGLPresent(unsigned width, unsigned height,
+		const struct mLibretroVideoGLPostProcessing* postProcessing) {
+	GLuint frontendFramebuffer;
+
+	if (!s_video.contextReady || !s_video.rendererEnabled ||
+			!s_video.outputFramebuffer || !s_video.callback.get_current_framebuffer) {
+		return false;
+	}
+
+	frontendFramebuffer = (GLuint) s_video.callback.get_current_framebuffer();
+	if (!mLibretroVideoGLPostProcessApply(frontendFramebuffer,
+			s_video.outputFramebuffer, s_video.outputTexture,
+			width, height, postProcessing)) {
+		glBindFramebuffer(GL_READ_FRAMEBUFFER, s_video.outputFramebuffer);
+		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, frontendFramebuffer);
+		glBlitFramebuffer(0, 0, (GLint) width, (GLint) height,
+			0, 0, (GLint) width, (GLint) height,
+			GL_COLOR_BUFFER_BIT, GL_NEAREST);
+	}
+
+	mLibretroGLResetState();
+	glBindFramebuffer(GL_FRAMEBUFFER, frontendFramebuffer);
+	glViewport(0, 0, (GLsizei) width, (GLsizei) height);
+	return true;
+}

--- a/src/platform/libretro/libretro_video_gl.h
+++ b/src/platform/libretro/libretro_video_gl.h
@@ -1,0 +1,42 @@
+/* Copyright (c) 2013-2026 mGBA contributors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+#ifndef M_LIBRETRO_VIDEO_GL_H
+#define M_LIBRETRO_VIDEO_GL_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "libretro.h"
+
+struct mCore;
+
+enum mLibretroVideoGLFrameBlend {
+	mLIBRETRO_VIDEO_GL_FRAME_BLEND_NONE = 0,
+	mLIBRETRO_VIDEO_GL_FRAME_BLEND_MIX,
+	mLIBRETRO_VIDEO_GL_FRAME_BLEND_MIX_SMART,
+	mLIBRETRO_VIDEO_GL_FRAME_BLEND_LCD_GHOSTING,
+	mLIBRETRO_VIDEO_GL_FRAME_BLEND_LCD_GHOSTING_FAST,
+};
+
+struct mLibretroVideoGLPostProcessing {
+	bool colorCorrectionEnabled;
+	const uint16_t* colorCorrectionLut;
+	unsigned colorCorrectionType;
+	enum mLibretroVideoGLFrameBlend frameBlend;
+};
+
+void mLibretroVideoGLInit(retro_environment_t environment, retro_log_printf_t logCallback);
+bool mLibretroVideoGLRequest(struct mCore* core);
+void mLibretroVideoGLDeinit(void);
+
+bool mLibretroVideoGLIsRequested(void);
+bool mLibretroVideoGLGetSize(const struct mCore* core, unsigned* width, unsigned* height);
+
+void mLibretroVideoGLBeginFrame(void);
+bool mLibretroVideoGLPresent(unsigned width, unsigned height,
+	const struct mLibretroVideoGLPostProcessing* postProcessing);
+
+#endif

--- a/src/platform/libretro/libretro_video_gl_postprocess.c
+++ b/src/platform/libretro/libretro_video_gl_postprocess.c
@@ -1,0 +1,614 @@
+/* Copyright (c) 2013-2026 mGBA contributors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+#include "libretro_video_gl_postprocess.h"
+
+#include <string.h>
+
+#if defined(COLOR_16_BIT) && defined(COLOR_5_6_5)
+
+enum {
+	M_LIBRETRO_VIDEO_GL_HISTORY_MAX = 4,
+	M_LIBRETRO_VIDEO_GL_FAST_TEXTURES = 2,
+	M_LIBRETRO_VIDEO_GL_COLOR_LUT_UNIT = 5,
+};
+
+struct mLibretroVideoGLPostProcessor {
+	retro_log_printf_t logCallback;
+	GLuint program;
+	GLuint vao;
+	GLint currentLocation;
+	GLint historyLocations[M_LIBRETRO_VIDEO_GL_HISTORY_MAX];
+	GLint colorLutLocation;
+	GLint blendModeLocation;
+	GLint colorCorrectionLocation;
+	GLuint colorCorrectionTexture;
+	unsigned uploadedColorCorrectionType;
+	unsigned failedColorCorrectionType;
+	GLuint historyTextures[M_LIBRETRO_VIDEO_GL_HISTORY_MAX];
+	GLuint historyFramebuffers[M_LIBRETRO_VIDEO_GL_HISTORY_MAX];
+	GLuint fastTextures[M_LIBRETRO_VIDEO_GL_FAST_TEXTURES];
+	GLuint fastFramebuffers[M_LIBRETRO_VIDEO_GL_FAST_TEXTURES];
+	unsigned width;
+	unsigned height;
+	enum mLibretroVideoGLFrameBlend blendMode;
+	unsigned historyCount;
+	unsigned fastReadIndex;
+	unsigned failedWidth;
+	unsigned failedHeight;
+	enum mLibretroVideoGLFrameBlend failedBlendMode;
+	bool programReady;
+	bool resourcesReady;
+	bool resourceFailure;
+	bool failureLogged;
+	bool colorLutFailure;
+	bool colorLutFailureLogged;
+};
+
+static struct mLibretroVideoGLPostProcessor s_post;
+
+static void _resetUniformLocations(void) {
+	s_post.currentLocation = -1;
+	memset(s_post.historyLocations, 0xFF, sizeof(s_post.historyLocations));
+	s_post.colorLutLocation = -1;
+	s_post.blendModeLocation = -1;
+	s_post.colorCorrectionLocation = -1;
+}
+
+void mLibretroVideoGLPostProcessInit(retro_log_printf_t logCallback) {
+	memset(&s_post, 0, sizeof(s_post));
+	s_post.logCallback = logCallback;
+	s_post.blendMode = mLIBRETRO_VIDEO_GL_FRAME_BLEND_NONE;
+	s_post.failedBlendMode = mLIBRETRO_VIDEO_GL_FRAME_BLEND_NONE;
+	_resetUniformLocations();
+}
+
+/* The shader blendMode values intentionally mirror mLibretroVideoGLFrameBlend. */
+static const char* const _postVertexShader =
+	"#version 330 core\n"
+	"out vec2 texCoord;\n"
+	"void main() {\n"
+	"\tvec2 position = vec2(float((gl_VertexID << 1) & 2), float(gl_VertexID & 2));\n"
+	"\ttexCoord = position;\n"
+	"\tgl_Position = vec4(position * 2.0 - 1.0, 0.0, 1.0);\n"
+	"}\n";
+
+static const char* const _postFragmentShader =
+	"#version 330 core\n"
+	"in vec2 texCoord;\n"
+	"layout(location = 0) out vec4 fragColor;\n"
+	"uniform sampler2D currentTex;\n"
+	"uniform sampler2D history1;\n"
+	"uniform sampler2D history2;\n"
+	"uniform sampler2D history3;\n"
+	"uniform sampler2D history4;\n"
+	"uniform sampler2D colorLut;\n"
+	"uniform int blendMode;\n"
+	"uniform int colorCorrection;\n"
+	"ivec3 mixColor5(ivec3 current, ivec3 previous) {\n"
+	"\tivec3 total = current + previous;\n"
+	"\treturn ivec3((total.r + 1) / 2, total.g / 2, (total.b + 1) / 2);\n"
+	"}\n"
+	"vec3 displayColor(ivec3 color5) {\n"
+	"\treturn vec3(float(color5.r) / 31.0, float(color5.g * 2) / 63.0,\n"
+	"\t\tfloat(color5.b) / 31.0);\n"
+	"}\n"
+	"vec3 mixDisplayColor(ivec3 current, ivec3 previous) {\n"
+	"\tivec3 total = current + previous;\n"
+	"\treturn vec3(float((total.r + 1) / 2) / 31.0, float(total.g) / 63.0,\n"
+	"\t\tfloat((total.b + 1) / 2) / 31.0);\n"
+	"}\n"
+	"vec3 correctColor(ivec3 color5) {\n"
+	"\tint index = (color5.r << 11) | (color5.g << 6) | color5.b;\n"
+	"\treturn texelFetch(colorLut, ivec2(index & 255, index >> 8), 0).rgb;\n"
+	"}\n"
+	"void main() {\n"
+	"\tvec3 currentRaw = clamp(texture(currentTex, texCoord).rgb, 0.0, 1.0);\n"
+	"\tvec3 historyRaw1 = clamp(texture(history1, texCoord).rgb, 0.0, 1.0);\n"
+	"\tivec3 current5 = ivec3(floor(currentRaw * 31.0 + 0.5));\n"
+	"\tivec3 previous1 = ivec3(floor(historyRaw1 * 31.0 + 0.5));\n"
+	"\tivec3 previous2 = ivec3(floor(clamp(texture(history2, texCoord).rgb, 0.0, 1.0) * 31.0 + 0.5));\n"
+	"\tivec3 previous3 = ivec3(floor(clamp(texture(history3, texCoord).rgb, 0.0, 1.0) * 31.0 + 0.5));\n"
+	"\tivec3 previous4 = ivec3(floor(clamp(texture(history4, texCoord).rgb, 0.0, 1.0) * 31.0 + 0.5));\n"
+	"\tivec3 correctionColor5 = current5;\n"
+	"\tvec3 outputColor = displayColor(current5);\n"
+	"\tif (blendMode == 1) {\n"
+	"\t\tcorrectionColor5 = mixColor5(current5, previous1);\n"
+	"\t\toutputColor = mixDisplayColor(current5, previous1);\n"
+	"\t} else if (blendMode == 2) {\n"
+	"\t\tbool alternating = (all(equal(current5, previous2)) || all(equal(previous1, previous3))) &&\n"
+	"\t\t\t!all(equal(current5, previous1)) && !all(equal(current5, previous3)) &&\n"
+	"\t\t\t!all(equal(previous1, previous2));\n"
+	"\t\tif (alternating) {\n"
+	"\t\t\tcorrectionColor5 = mixColor5(current5, previous1);\n"
+	"\t\t\toutputColor = mixDisplayColor(current5, previous1);\n"
+	"\t\t}\n"
+	"\t} else if (blendMode == 3) {\n"
+	"\t\tvec3 ghost = vec3(current5);\n"
+	"\t\tghost += (vec3(previous1) - ghost) * 0.333;\n"
+	"\t\tghost += (vec3(previous2) - ghost) * 0.110889;\n"
+	"\t\tghost += (vec3(previous3) - ghost) * 0.036926037;\n"
+	"\t\tghost += (vec3(previous4) - ghost) * 0.012296970321;\n"
+	"\t\tcorrectionColor5 = ivec3(floor(ghost + 0.5));\n"
+	"\t\toutputColor = displayColor(correctionColor5);\n"
+	"\t} else if (blendMode == 4) {\n"
+	"\t\toutputColor = (vec3(current5) + historyRaw1 * 31.0) * (0.5 / 31.0);\n"
+	"\t}\n"
+	"\tif (colorCorrection != 0) {\n"
+	"\t\toutputColor = correctColor(correctionColor5);\n"
+	"\t}\n"
+	"\tfragColor = vec4(clamp(outputColor, 0.0, 1.0), 1.0);\n"
+	"}\n";
+
+
+static GLuint _compileShader(GLenum type, const char* source) {
+	GLuint shader = glCreateShader(type);
+	GLint status = GL_FALSE;
+	GLchar log[2048] = {0};
+
+	if (!shader) {
+		return 0;
+	}
+	glShaderSource(shader, 1, &source, NULL);
+	glCompileShader(shader);
+	glGetShaderiv(shader, GL_COMPILE_STATUS, &status);
+	if (status == GL_TRUE) {
+		return shader;
+	}
+
+	glGetShaderInfoLog(shader, sizeof(log), NULL, log);
+	if (s_post.logCallback) {
+		s_post.logCallback(RETRO_LOG_ERROR,
+			"OpenGL post-processing shader compilation failed: %s\n", log);
+	}
+	glDeleteShader(shader);
+	return 0;
+}
+
+static bool _uniformLocationsValid(void) {
+	unsigned i;
+
+	if (s_post.currentLocation < 0 || s_post.colorLutLocation < 0 ||
+			s_post.blendModeLocation < 0 || s_post.colorCorrectionLocation < 0) {
+		return false;
+	}
+	for (i = 0; i < M_LIBRETRO_VIDEO_GL_HISTORY_MAX; ++i) {
+		if (s_post.historyLocations[i] < 0) {
+			return false;
+		}
+	}
+	return true;
+}
+
+bool mLibretroVideoGLPostProcessCreate(void) {
+	GLuint vertexShader;
+	GLuint fragmentShader;
+	GLint status = GL_FALSE;
+	GLchar log[2048] = {0};
+	unsigned i;
+
+	if (s_post.programReady) {
+		return true;
+	}
+
+	vertexShader = _compileShader(GL_VERTEX_SHADER, _postVertexShader);
+	if (!vertexShader) {
+		return false;
+	}
+	fragmentShader = _compileShader(GL_FRAGMENT_SHADER, _postFragmentShader);
+	if (!fragmentShader) {
+		glDeleteShader(vertexShader);
+		return false;
+	}
+
+	s_post.program = glCreateProgram();
+	if (!s_post.program) {
+		glDeleteShader(vertexShader);
+		glDeleteShader(fragmentShader);
+		return false;
+	}
+	glAttachShader(s_post.program, vertexShader);
+	glAttachShader(s_post.program, fragmentShader);
+	glLinkProgram(s_post.program);
+	glGetProgramiv(s_post.program, GL_LINK_STATUS, &status);
+	glDeleteShader(vertexShader);
+	glDeleteShader(fragmentShader);
+	if (status != GL_TRUE) {
+		glGetProgramInfoLog(s_post.program, sizeof(log), NULL, log);
+		if (s_post.logCallback) {
+			s_post.logCallback(RETRO_LOG_ERROR,
+				"OpenGL post-processing shader link failed: %s\n", log);
+		}
+		glDeleteProgram(s_post.program);
+		s_post.program = 0;
+		return false;
+	}
+
+	glGenVertexArrays(1, &s_post.vao);
+	if (!s_post.vao) {
+		glDeleteProgram(s_post.program);
+		s_post.program = 0;
+		return false;
+	}
+
+	s_post.currentLocation = glGetUniformLocation(s_post.program, "currentTex");
+	s_post.historyLocations[0] = glGetUniformLocation(s_post.program, "history1");
+	s_post.historyLocations[1] = glGetUniformLocation(s_post.program, "history2");
+	s_post.historyLocations[2] = glGetUniformLocation(s_post.program, "history3");
+	s_post.historyLocations[3] = glGetUniformLocation(s_post.program, "history4");
+	s_post.colorLutLocation = glGetUniformLocation(s_post.program, "colorLut");
+	s_post.blendModeLocation = glGetUniformLocation(s_post.program, "blendMode");
+	s_post.colorCorrectionLocation = glGetUniformLocation(s_post.program, "colorCorrection");
+	if (!_uniformLocationsValid()) {
+		if (s_post.logCallback) {
+			s_post.logCallback(RETRO_LOG_ERROR,
+				"OpenGL post-processing shader is missing a required uniform.\n");
+		}
+		glDeleteVertexArrays(1, &s_post.vao);
+		glDeleteProgram(s_post.program);
+		s_post.vao = 0;
+		s_post.program = 0;
+		_resetUniformLocations();
+		return false;
+	}
+
+	glUseProgram(s_post.program);
+	glUniform1i(s_post.currentLocation, 0);
+	for (i = 0; i < M_LIBRETRO_VIDEO_GL_HISTORY_MAX; ++i) {
+		glUniform1i(s_post.historyLocations[i], (GLint) i + 1);
+	}
+	glUniform1i(s_post.colorLutLocation, M_LIBRETRO_VIDEO_GL_COLOR_LUT_UNIT);
+	glUseProgram(0);
+	s_post.programReady = true;
+	return true;
+}
+
+static void _destroyResources(bool contextValid) {
+	if (contextValid) {
+		glDeleteTextures(M_LIBRETRO_VIDEO_GL_HISTORY_MAX, s_post.historyTextures);
+		glDeleteFramebuffers(M_LIBRETRO_VIDEO_GL_HISTORY_MAX, s_post.historyFramebuffers);
+		glDeleteTextures(M_LIBRETRO_VIDEO_GL_FAST_TEXTURES, s_post.fastTextures);
+		glDeleteFramebuffers(M_LIBRETRO_VIDEO_GL_FAST_TEXTURES, s_post.fastFramebuffers);
+	}
+	memset(s_post.historyTextures, 0, sizeof(s_post.historyTextures));
+	memset(s_post.historyFramebuffers, 0, sizeof(s_post.historyFramebuffers));
+	memset(s_post.fastTextures, 0, sizeof(s_post.fastTextures));
+	memset(s_post.fastFramebuffers, 0, sizeof(s_post.fastFramebuffers));
+	s_post.width = 0;
+	s_post.height = 0;
+	s_post.blendMode = mLIBRETRO_VIDEO_GL_FRAME_BLEND_NONE;
+	s_post.historyCount = 0;
+	s_post.fastReadIndex = 0;
+	s_post.resourcesReady = false;
+}
+
+void mLibretroVideoGLPostProcessDestroy(bool contextValid) {
+	retro_log_printf_t logCallback = s_post.logCallback;
+
+	_destroyResources(contextValid);
+	if (contextValid) {
+		if (s_post.colorCorrectionTexture) {
+			glDeleteTextures(1, &s_post.colorCorrectionTexture);
+		}
+		if (s_post.vao) {
+			glDeleteVertexArrays(1, &s_post.vao);
+		}
+		if (s_post.program) {
+			glDeleteProgram(s_post.program);
+		}
+	}
+	memset(&s_post, 0, sizeof(s_post));
+	s_post.logCallback = logCallback;
+	s_post.blendMode = mLIBRETRO_VIDEO_GL_FRAME_BLEND_NONE;
+	s_post.failedBlendMode = mLIBRETRO_VIDEO_GL_FRAME_BLEND_NONE;
+	_resetUniformLocations();
+}
+
+static bool _createTexture(GLuint* texture, GLuint* framebuffer,
+		GLenum internalFormat, GLenum type, unsigned width, unsigned height,
+		float clearValue) {
+	GLenum drawBuffer = GL_COLOR_ATTACHMENT0;
+
+	*texture = 0;
+	*framebuffer = 0;
+	glGenTextures(1, texture);
+	if (!*texture) {
+		return false;
+	}
+	glBindTexture(GL_TEXTURE_2D, *texture);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	glTexImage2D(GL_TEXTURE_2D, 0, (GLint) internalFormat,
+		(GLsizei) width, (GLsizei) height, 0, GL_RGB, type, NULL);
+
+	glGenFramebuffers(1, framebuffer);
+	if (!*framebuffer) {
+		glDeleteTextures(1, texture);
+		*texture = 0;
+		return false;
+	}
+	glBindFramebuffer(GL_FRAMEBUFFER, *framebuffer);
+	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+		GL_TEXTURE_2D, *texture, 0);
+	glDrawBuffers(1, &drawBuffer);
+	if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+		glDeleteFramebuffers(1, framebuffer);
+		glDeleteTextures(1, texture);
+		*framebuffer = 0;
+		*texture = 0;
+		return false;
+	}
+
+	glViewport(0, 0, (GLsizei) width, (GLsizei) height);
+	glClearColor(clearValue, clearValue, clearValue, 1.0f);
+	glClear(GL_COLOR_BUFFER_BIT);
+	return true;
+}
+
+static unsigned _historyCount(enum mLibretroVideoGLFrameBlend blendMode) {
+	switch (blendMode) {
+	case mLIBRETRO_VIDEO_GL_FRAME_BLEND_MIX:
+		return 1;
+	case mLIBRETRO_VIDEO_GL_FRAME_BLEND_MIX_SMART:
+		return 3;
+	case mLIBRETRO_VIDEO_GL_FRAME_BLEND_LCD_GHOSTING:
+		return 4;
+	default:
+		return 0;
+	}
+}
+
+static bool _sameFailedConfiguration(unsigned width, unsigned height,
+		enum mLibretroVideoGLFrameBlend blendMode) {
+	return s_post.resourceFailure && s_post.failedWidth == width &&
+		s_post.failedHeight == height && s_post.failedBlendMode == blendMode;
+}
+
+static bool _configureResources(unsigned width, unsigned height,
+		enum mLibretroVideoGLFrameBlend blendMode) {
+	unsigned i;
+	unsigned historyCount;
+
+	if (s_post.resourcesReady && s_post.width == width &&
+			s_post.height == height && s_post.blendMode == blendMode) {
+		return true;
+	}
+	if (_sameFailedConfiguration(width, height, blendMode)) {
+		return false;
+	}
+
+	_destroyResources(true);
+	s_post.resourceFailure = false;
+	s_post.width = width;
+	s_post.height = height;
+	s_post.blendMode = blendMode;
+	historyCount = _historyCount(blendMode);
+	s_post.historyCount = historyCount;
+
+	for (i = 0; i < historyCount; ++i) {
+		if (!_createTexture(&s_post.historyTextures[i],
+				&s_post.historyFramebuffers[i], GL_RGB565,
+				GL_UNSIGNED_SHORT_5_6_5, width, height, 1.0f)) {
+			goto fail;
+		}
+	}
+	if (blendMode == mLIBRETRO_VIDEO_GL_FRAME_BLEND_LCD_GHOSTING_FAST) {
+		for (i = 0; i < M_LIBRETRO_VIDEO_GL_FAST_TEXTURES; ++i) {
+			if (!_createTexture(&s_post.fastTextures[i],
+					&s_post.fastFramebuffers[i], GL_RGB16F,
+					GL_FLOAT, width, height, 1.0f / 31.0f)) {
+				goto fail;
+			}
+		}
+	}
+
+	s_post.resourcesReady = true;
+	return true;
+
+fail:
+	_destroyResources(true);
+	s_post.resourceFailure = true;
+	s_post.failedWidth = width;
+	s_post.failedHeight = height;
+	s_post.failedBlendMode = blendMode;
+	return false;
+}
+
+static bool _uploadColorCorrectionLut(const uint16_t* colorLut,
+		unsigned colorCorrectionType) {
+	if (!colorLut) {
+		return false;
+	}
+	if (s_post.colorCorrectionTexture &&
+			s_post.uploadedColorCorrectionType == colorCorrectionType) {
+		return true;
+	}
+	if (s_post.colorLutFailure &&
+			s_post.failedColorCorrectionType == colorCorrectionType) {
+		return false;
+	}
+
+	glActiveTexture(GL_TEXTURE0 + M_LIBRETRO_VIDEO_GL_COLOR_LUT_UNIT);
+	if (!s_post.colorCorrectionTexture) {
+		glGenTextures(1, &s_post.colorCorrectionTexture);
+		if (!s_post.colorCorrectionTexture) {
+			s_post.colorLutFailure = true;
+			s_post.failedColorCorrectionType = colorCorrectionType;
+			return false;
+		}
+		glBindTexture(GL_TEXTURE_2D, s_post.colorCorrectionTexture);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	} else {
+		glBindTexture(GL_TEXTURE_2D, s_post.colorCorrectionTexture);
+	}
+
+	glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+	glPixelStorei(GL_UNPACK_ALIGNMENT, 2);
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB565, 256, 256, 0,
+		GL_RGB, GL_UNSIGNED_SHORT_5_6_5, colorLut);
+	s_post.uploadedColorCorrectionType = colorCorrectionType;
+	s_post.colorLutFailure = false;
+	return true;
+}
+
+static void _draw(GLuint targetFramebuffer, bool privateFramebuffer,
+		GLuint currentTexture, const GLuint* historyTextures,
+		enum mLibretroVideoGLFrameBlend blendMode, bool colorCorrection,
+		unsigned width, unsigned height) {
+	GLenum drawBuffer = GL_COLOR_ATTACHMENT0;
+	unsigned i;
+
+	mLibretroGLResetState();
+	glBindFramebuffer(GL_FRAMEBUFFER, targetFramebuffer);
+	if (privateFramebuffer) {
+		glDrawBuffers(1, &drawBuffer);
+	}
+	glViewport(0, 0, (GLsizei) width, (GLsizei) height);
+	glUseProgram(s_post.program);
+	glBindVertexArray(s_post.vao);
+
+	glActiveTexture(GL_TEXTURE0);
+	glBindTexture(GL_TEXTURE_2D, currentTexture);
+	for (i = 0; i < M_LIBRETRO_VIDEO_GL_HISTORY_MAX; ++i) {
+		GLuint historyTexture = historyTextures && historyTextures[i]
+			? historyTextures[i] : currentTexture;
+		glActiveTexture(GL_TEXTURE0 + i + 1);
+		glBindTexture(GL_TEXTURE_2D, historyTexture);
+	}
+	glActiveTexture(GL_TEXTURE0 + M_LIBRETRO_VIDEO_GL_COLOR_LUT_UNIT);
+	glBindTexture(GL_TEXTURE_2D,
+		colorCorrection ? s_post.colorCorrectionTexture : currentTexture);
+	glUniform1i(s_post.blendModeLocation, (GLint) blendMode);
+	glUniform1i(s_post.colorCorrectionLocation, colorCorrection ? 1 : 0);
+	glDrawArrays(GL_TRIANGLES, 0, 3);
+}
+
+static void _updateHistory(GLuint sourceFramebuffer,
+		unsigned width, unsigned height) {
+	unsigned i;
+
+	for (i = s_post.historyCount; i > 1; --i) {
+		glBindFramebuffer(GL_READ_FRAMEBUFFER,
+			s_post.historyFramebuffers[i - 2]);
+		glBindFramebuffer(GL_DRAW_FRAMEBUFFER,
+			s_post.historyFramebuffers[i - 1]);
+		glBlitFramebuffer(0, 0, (GLint) width, (GLint) height,
+			0, 0, (GLint) width, (GLint) height,
+			GL_COLOR_BUFFER_BIT, GL_NEAREST);
+	}
+	if (s_post.historyCount) {
+		glBindFramebuffer(GL_READ_FRAMEBUFFER, sourceFramebuffer);
+		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, s_post.historyFramebuffers[0]);
+		glBlitFramebuffer(0, 0, (GLint) width, (GLint) height,
+			0, 0, (GLint) width, (GLint) height,
+			GL_COLOR_BUFFER_BIT, GL_NEAREST);
+	}
+}
+
+bool mLibretroVideoGLPostProcessApply(GLuint targetFramebuffer,
+		GLuint sourceFramebuffer, GLuint sourceTexture,
+		unsigned width, unsigned height,
+		const struct mLibretroVideoGLPostProcessing* settings) {
+	enum mLibretroVideoGLFrameBlend blendMode;
+	bool colorCorrection;
+	bool requested;
+
+	if (!settings || !s_post.programReady) {
+		return false;
+	}
+
+	blendMode = settings->frameBlend;
+	if (!settings->colorCorrectionEnabled) {
+		s_post.colorLutFailure = false;
+		s_post.colorLutFailureLogged = false;
+	}
+	colorCorrection = settings->colorCorrectionEnabled &&
+		_uploadColorCorrectionLut(settings->colorCorrectionLut,
+			settings->colorCorrectionType);
+	if (settings->colorCorrectionEnabled && !colorCorrection) {
+		if (!s_post.colorLutFailureLogged && s_post.logCallback) {
+			s_post.logCallback(RETRO_LOG_WARN,
+				"OpenGL color-correction LUT could not be uploaded; color correction is disabled for this frame.\n");
+		}
+		s_post.colorLutFailureLogged = true;
+	} else {
+		s_post.colorLutFailureLogged = false;
+	}
+	requested = blendMode != mLIBRETRO_VIDEO_GL_FRAME_BLEND_NONE ||
+		colorCorrection;
+	if (!requested) {
+		if (s_post.resourcesReady) {
+			_destroyResources(true);
+		}
+		s_post.resourceFailure = false;
+		s_post.failureLogged = false;
+		return false;
+	}
+
+	if (!_configureResources(width, height, blendMode)) {
+		if (!s_post.failureLogged && s_post.logCallback) {
+			s_post.logCallback(RETRO_LOG_WARN,
+				"OpenGL post-processing resources could not be created; "
+				"displaying the unprocessed high-resolution frame.\n");
+		}
+		s_post.failureLogged = true;
+		return false;
+	}
+	s_post.failureLogged = false;
+
+	if (blendMode == mLIBRETRO_VIDEO_GL_FRAME_BLEND_LCD_GHOSTING_FAST) {
+		unsigned writeIndex = s_post.fastReadIndex ^ 1U;
+		GLuint fastHistory[M_LIBRETRO_VIDEO_GL_HISTORY_MAX] = {
+			s_post.fastTextures[s_post.fastReadIndex], 0, 0, 0
+		};
+
+		_draw(s_post.fastFramebuffers[writeIndex], true, sourceTexture,
+			fastHistory, mLIBRETRO_VIDEO_GL_FRAME_BLEND_LCD_GHOSTING_FAST,
+			false, width, height);
+		_draw(targetFramebuffer, false, s_post.fastTextures[writeIndex],
+			NULL, mLIBRETRO_VIDEO_GL_FRAME_BLEND_NONE,
+			colorCorrection, width, height);
+		s_post.fastReadIndex = writeIndex;
+	} else {
+		_draw(targetFramebuffer, false, sourceTexture, s_post.historyTextures,
+			blendMode, colorCorrection, width, height);
+		_updateHistory(sourceFramebuffer, width, height);
+	}
+	return true;
+}
+
+#else
+
+void mLibretroVideoGLPostProcessInit(retro_log_printf_t logCallback) {
+	(void) logCallback;
+}
+
+bool mLibretroVideoGLPostProcessCreate(void) {
+	return false;
+}
+
+void mLibretroVideoGLPostProcessDestroy(bool contextValid) {
+	(void) contextValid;
+}
+
+bool mLibretroVideoGLPostProcessApply(GLuint targetFramebuffer,
+		GLuint sourceFramebuffer, GLuint sourceTexture,
+		unsigned width, unsigned height,
+		const struct mLibretroVideoGLPostProcessing* settings) {
+	(void) targetFramebuffer;
+	(void) sourceFramebuffer;
+	(void) sourceTexture;
+	(void) width;
+	(void) height;
+	(void) settings;
+	return false;
+}
+
+#endif

--- a/src/platform/libretro/libretro_video_gl_postprocess.h
+++ b/src/platform/libretro/libretro_video_gl_postprocess.h
@@ -1,0 +1,21 @@
+/* Copyright (c) 2013-2026 mGBA contributors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+#ifndef M_LIBRETRO_VIDEO_GL_POSTPROCESS_H
+#define M_LIBRETRO_VIDEO_GL_POSTPROCESS_H
+
+#include "libretro_gl.h"
+#include "libretro_video_gl.h"
+
+void mLibretroVideoGLPostProcessInit(retro_log_printf_t logCallback);
+bool mLibretroVideoGLPostProcessCreate(void);
+void mLibretroVideoGLPostProcessDestroy(bool contextValid);
+
+bool mLibretroVideoGLPostProcessApply(GLuint targetFramebuffer,
+	GLuint sourceFramebuffer, GLuint sourceTexture,
+	unsigned width, unsigned height,
+	const struct mLibretroVideoGLPostProcessing* settings);
+
+#endif


### PR DESCRIPTION
This PR adds the OpenGL high-resolution renderer to the mGBA libretro core.

This feature has been requested since 2019 in #156, so I thought it was worth giving it a try

It adds:

- An optional OpenGL renderer for GBA games
- Internal resolution scaling from 1x to 16x
- Support for color correction and the existing blending modes in GL mode
- Automatic fallback to the software renderer if OpenGL is unavailable
- Context reset and content reload handling
- Windows, Linux and CMake build support

The software renderer is still the default, and GB/GBC games continue to use it.

I tested the core in RetroArch on Windows at 1x and 4x. I also tested color correction, all blending modes, fullscreen switching and opening the RetroArch menu. Everything worked correctly on my side :)

Small disclaimer: this was heavily vibe-coded with AI assistance

However, the code was reviewed, revised several times, compiled with GCC and Clang, checked with static analysis, and tested in a real RetroArch setup.

Closes #156